### PR TITLE
multi-thread and multi-build safe (filelocks around io operations)

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -24,8 +24,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -96,11 +96,6 @@
 			<artifactId>maven-project</artifactId>
 			<version>2.0</version>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/download-maven-plugin/src/it/GetAndUnpack/pom.xml
+++ b/download-maven-plugin/src/it/GetAndUnpack/pom.xml
@@ -13,8 +13,8 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>0.2-SNAPSHOT</version>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/download-maven-plugin/src/it/basicGet/pom.xml
+++ b/download-maven-plugin/src/it/basicGet/pom.xml
@@ -13,8 +13,8 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>0.2-SNAPSHOT</version>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/download-maven-plugin/src/it/basicGetWithSignature/pom.xml
+++ b/download-maven-plugin/src/it/basicGetWithSignature/pom.xml
@@ -13,8 +13,8 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>0.2-SNAPSHOT</version>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/download-maven-plugin/src/it/basicGetWrongSignature/pom.xml
+++ b/download-maven-plugin/src/it/basicGetWrongSignature/pom.xml
@@ -13,8 +13,8 @@
 		<plugins>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
-				<version>0.2-SNAPSHOT</version>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
@@ -17,11 +17,12 @@ package com.googlecode;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -224,7 +225,7 @@ public class Artifact extends AbstractMojo {
 				}else{
 					outputFile = new File(outputDirectory, this.outputFileName);
 				}
-				FileUtils.copyFile(toCopy, outputFile);
+                Files.copy(toCopy.toPath(), outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				getLog().debug("Error while copying file", e);
 				throw new MojoFailureException("Error copying the file : " + e.getMessage());

--- a/download-maven-plugin/src/main/java/com/googlecode/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/WGet.java
@@ -15,7 +15,6 @@
  */
 package com.googlecode;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -29,6 +28,7 @@ import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 
 /**
@@ -211,7 +211,7 @@ public class WGet extends AbstractMojo {
         if (!this.skipCache && cached != null && cached.exists())
         {
           getLog().info("Got from cache: " + cached.getAbsolutePath());
-          FileUtils.copyFile(cached, outputFile);
+          Files.copy(cached.toPath(), outputFile.toPath());
         }
         else
         {


### PR DESCRIPTION
download-maven-plugin easily breaks with multiple threads builds (-T option), or with multiple builds running in parallel.

For example the plugin will often fail on ci (bamboo, jenkins, etc) servers with EOFException (DownloadCache.loadIndex(DownloadCache.java:105)) or IOException "Failed to copy full contents from …" (DownloadCache.install(DownloadCache.java:95)).

Some projects would fail >50% of builds due to the lack safe concurrent file operations.

These concerns are also raised by https://github.com/maven-download-plugin/maven-download-plugin/issues/2

This pull request solves these problems by using FileLocks and Java7's nio enhancements.
Copying files is done "safely" with Files.copy(..), and load and saving the cache index file is down with FileLocks.

Some extras
 - Java7 try-resource has been taken advantage of as well.
 - The integration tests were made to work again by bringing the version up to date and correcting the arfitactId.
 - "cache.install(..)" was moved up a few lines so that it's only called when a new file has been downloaded.
 - the check and creation of basedir moved from saveIndex to constructor since Files.copy(..) in install(..) would fault otherwise, see line 107.
 - trailing spaces removed.

