### PR TITLE
Update WGet.java - get rid of double forward url ending slash

### DIFF
--- a/download-maven-plugin/src/main/java/com/googlecode/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/WGet.java
@@ -274,7 +274,7 @@ public class WGet extends AbstractMojo {
   private void doGet(File outputFile) throws Exception {
     String[] segments = this.url.split("/");
     String file = segments[segments.length - 1];
-    String repoUrl = this.url.substring(0, this.url.length() - file.length());
+    String repoUrl = this.url.substring(0, this.url.length() - file.length() - 1);
     Repository repository = new Repository(repoUrl, repoUrl);
 
     Wagon wagon = this.wagonManager.getWagon(repository.getProtocol());


### PR DESCRIPTION
Without the patch, the configuration:
<url>http://localhost:8080/service/persons?wsdl</url>
results in an attempt of downloading the file with double forward slash at the end of the 'repoURL':
Downloading: http://localhost:8080/service//persons?wsdl

With the patch the double forward slash is removed:
Downloading: http://localhost:8080/service/persons?wsdl
