### PR TITLE
Creating outputDirectory if not exists for Archive goal

### DIFF
--- a/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
@@ -236,6 +236,9 @@ public class Artifact extends AbstractMojo {
 	}
 
 	private void unpackFileToDirectory(org.apache.maven.artifact.Artifact artifact) throws MojoExecutionException {
+		if (!this.outputDirectory.exists()) {
+			this.outputDirectory.mkdir();
+		}
 		File toUnpack = artifact.getFile();
 		if (toUnpack != null && toUnpack.exists() && toUnpack.isFile()) {
 			try {


### PR DESCRIPTION
UnArchiver expect the output folder to exist. This is the behavior in the WGet goal.