### PR TITLE
Fix false cache hit

### DIFF
--- a/download-maven-plugin/src/main/java/com/googlecode/CachedFileEntry.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/CachedFileEntry.java
@@ -26,14 +26,4 @@ class CachedFileEntry implements Serializable {
 	private static final long serialVersionUID = 322094691022939391L;
 
 	public String fileName;
-
-	/**
-	 * @deprecated As Entries can be updated externally and become
-	 * inconsistent, we mustnt store signatures and always need to
-	 * re-compute them
-	 */
-	@Deprecated
-	public String md5;
-	@Deprecated
-	public String sha1;
 }

--- a/download-maven-plugin/src/main/java/com/googlecode/DownloadCache.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/DownloadCache.java
@@ -15,6 +15,7 @@
  */
 package com.googlecode;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.*;
@@ -98,15 +99,13 @@ public class DownloadCache {
 			return; // entry already here
 		}
 		entry = new CachedFileEntry();
-		entry.fileName = outputFile.getName();
-        Files.copy(outputFile.toPath(), new File(this.basedir, entry.fileName).toPath(), StandardCopyOption.REPLACE_EXISTING);
-        // update index
+		entry.fileName = outputFile.getName() + '_' + DigestUtils.md5Hex(url);
+		Files.copy(outputFile.toPath(), new File(this.basedir, entry.fileName).toPath(), StandardCopyOption.REPLACE_EXISTING);
+		// update index
 		loadIndex();
 		this.index.put(url, entry);
 		saveIndex();
 	}
-
-
 
 	private void loadIndex() throws Exception {
         if (this.indexFile.isFile()) {

--- a/download-maven-plugin/src/main/java/com/googlecode/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/WGet.java
@@ -190,7 +190,7 @@ public class WGet extends AbstractMojo {
     if (this.cacheDirectory == null)
     {
       this.cacheDirectory = new File(this.session.getLocalRepository()
-          .getBasedir(), ".cache/maven-download-plugin");
+          .getBasedir(), ".cache/download-maven-plugin");
     }
     getLog().debug("Cache is: " + this.cacheDirectory.getAbsolutePath());
     DownloadCache cache = new DownloadCache(this.cacheDirectory);


### PR DESCRIPTION
There are two possible scenarios which may lead to false cache hit:
1: Multiple modules download files with the same name from different sources
2: Same module downloads a file from different urls, but with the same file name.
    In this case cache was hit because of file name even though url has changed.

Please see the test at 78d02cfa9762e9e410fc9ad6936be0bbdacdb2a2 Let me know if the test is valuable, I will include it into PR
