### PR TITLE
Added a new feature to always check signature of already downloaded files

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -63,6 +63,7 @@
 									<projectsDirectory>src/it</projectsDirectory>
 									<cloneProjectsTo>target/it</cloneProjectsTo>
 									<invokerPropertiesFile>invoke.properties</invokerPropertiesFile>
+									<preBuildHookScript>prepare.groovy</preBuildHookScript>
 									<postBuildHookScript>verify.groovy</postBuildHookScript>
 									<debug>true</debug>
 									<mavenOpts>-Dtesting.versionUnderTest=${version}</mavenOpts>
@@ -220,7 +221,7 @@
 			</plugin>
 		</plugins>
 	</reporting>
-	<!-- Distribution Management, see https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide 
+	<!-- Distribution Management, see https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
 		and http://maven.apache.org/wagon/wagon-providers/wagon-scm/usage.html -->
 	<distributionManagement>
 		<site>

--- a/download-maven-plugin/src/it/existingGetWithSignature/invoke.properties
+++ b/download-maven-plugin/src/it/existingGetWithSignature/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = package
+invoker.buildResult = success

--- a/download-maven-plugin/src/it/existingGetWithSignature/pom.xml
+++ b/download-maven-plugin/src/it/existingGetWithSignature/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test</name>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>${testing.versionUnderTest}</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
+							<md5>8412f316daecd4e8374a91fe13d9d657</md5>
+							<checkSignature>true</checkSignature>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/download-maven-plugin/src/it/existingGetWithSignature/prepare.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignature/prepare.groovy
@@ -1,0 +1,16 @@
+import junit.framework.Assert;
+
+File target = new File(basedir, "target/");
+if (!target.exists()) {
+  target.mkdirs();
+  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+}
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+if (f.exists()) {
+  f.delete();
+}
+f.createNewFile();
+
+Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
+Assert.assertNotSame("File need to be empty", 0, f.length());

--- a/download-maven-plugin/src/it/existingGetWithSignature/verify.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignature/verify.groovy
@@ -1,0 +1,5 @@
+import junit.framework.Assert;
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
+Assert.assertNotSame("File is empty", 0, f.length());

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha1/invoke.properties
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha1/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = package
+invoker.buildResult = success

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha1/pom.xml
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha1/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test</name>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>${testing.versionUnderTest}</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
+							<sha1>1fbcc78e41308b3f75f6695c20c10fa84ef4e271</sha1>
+							<checkSignature>true</checkSignature>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha1/prepare.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha1/prepare.groovy
@@ -1,0 +1,16 @@
+import junit.framework.Assert;
+
+File target = new File(basedir, "target/");
+if (!target.exists()) {
+  target.mkdirs();
+  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+}
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+if (f.exists()) {
+  f.delete();
+}
+f.createNewFile();
+
+Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
+Assert.assertNotSame("File need to be empty", 0, f.length());

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha1/verify.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha1/verify.groovy
@@ -1,0 +1,5 @@
+import junit.framework.Assert;
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
+Assert.assertNotSame("File is empty", 0, f.length());

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha512/invoke.properties
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha512/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = package
+invoker.buildResult = success

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha512/pom.xml
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha512/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test</name>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>${testing.versionUnderTest}</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
+							<sha512>b3fc94ecd8cda8acb15198e9b23da84e9de82274643819d8c19858d58132cf25cbd2da46e772a4b5ccac08d062069d234010d7c0e9d9728399ab4870948c2c95</sha512>
+							<checkSignature>true</checkSignature>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha512/prepare.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha512/prepare.groovy
@@ -1,0 +1,16 @@
+import junit.framework.Assert;
+
+File target = new File(basedir, "target/");
+if (!target.exists()) {
+  target.mkdirs();
+  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+}
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+if (f.exists()) {
+  f.delete();
+}
+f.createNewFile();
+
+Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
+Assert.assertNotSame("File need to be empty", 0, f.length());

--- a/download-maven-plugin/src/it/existingGetWithSignatureSha512/verify.groovy
+++ b/download-maven-plugin/src/it/existingGetWithSignatureSha512/verify.groovy
@@ -1,0 +1,5 @@
+import junit.framework.Assert;
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
+Assert.assertNotSame("File is empty", 0, f.length());

--- a/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/Artifact.java
@@ -15,14 +15,6 @@
  */
 package com.googlecode;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -39,6 +31,14 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.artifact.InvalidDependencyVersionException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * This mojo is designed to download a maven artifact from the repository and

--- a/download-maven-plugin/src/main/java/com/googlecode/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/WGet.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2009-2012 Marc-Andre Houle and Red Hat Inc
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -33,11 +33,11 @@ import java.security.MessageDigest;
 
 /**
  * Will download a file from a web site using the standard HTTP protocol.
- * 
+ *
  * @goal wget
  * @phase process-resources
  * @requiresProject false
- * 
+ *
  * @author Marc-Andre Houle
  * @author Mickael Istria (Red Hat Inc)
  */
@@ -46,15 +46,15 @@ public class WGet extends AbstractMojo {
 
   /**
    * Represent the URL to fetch information from.
-   * 
+   *
    * @parameter expression="${download.url}"
    * @required
    */
   private String url;
-  
+
   /**
    * Flag to overwrite the file by redownloading it
-   * 
+   *
    * @parameter expression="${download.overwrite}"
    */
   private boolean overwrite;
@@ -62,14 +62,14 @@ public class WGet extends AbstractMojo {
   /**
    * Represent the file name to use as output value. If not set, will use last
    * segment of "url"
-   * 
+   *
    * @parameter expression="${download.outputFileName}"
    */
   private String outputFileName;
 
   /**
    * Represent the directory where the file should be downloaded.
-   * 
+   *
    * @parameter expression="${download.outputDirectory}"
    *            default-value="${project.build.directory}"
    * @required
@@ -79,7 +79,7 @@ public class WGet extends AbstractMojo {
   /**
    * The md5 of the file. If set, file signature will be compared to this
    * signature and plugin will fail.
-   * 
+   *
    * @parameter
    */
   private String md5;
@@ -87,7 +87,7 @@ public class WGet extends AbstractMojo {
   /**
    * The sha1 of the file. If set, file signature will be compared to this
    * signature and plugin will fail.
-   * 
+   *
    * @parameter
    */
   private String sha1;
@@ -95,35 +95,35 @@ public class WGet extends AbstractMojo {
   /**
    * The sha512 of the file. If set, file signature will be compared to this
    * signature and plugin will fail.
-   * 
+   *
    * @parameter
    */
   private String sha512;
 
   /**
    * Whether to unpack the file in case it is an archive (.zip)
-   * 
+   *
    * @parameter default-value="false"
    */
   private boolean unpack;
 
   /**
    * How many retries for a download
-   * 
+   *
    * @parameter default-value="2"
    */
   private int retries;
 
   /**
    * Read timeout for a download in milliseconds
-   * 
+   *
    * @parameter default-value="0"
    */
   private int readTimeOut;
 
   /**
    * Download file without polling cache
-   * 
+   *
    * @parameter default-value="false"
    */
   private boolean skipCache;
@@ -131,7 +131,7 @@ public class WGet extends AbstractMojo {
   /**
    * The directory to use as a cache. Default is
    * ${local-repo}/.cache/maven-download-plugin
-   * 
+   *
    * @parameter expression="${download.cache.directory}"
    */
   private File cacheDirectory;
@@ -145,10 +145,16 @@ public class WGet extends AbstractMojo {
 
   /**
    * Whether to skip execution of Mojo
-   * 
+   *
    * @parameter expression="${download.plugin.skip}" default-value="false"
    */
   private boolean skip;
+
+  /**
+   * Whether to check the signature of existing files
+   * @parameter expression="${checkSignature}" default-value="false"
+   */
+  private boolean checkSignature;
 
   /**
    * @parameter default-value="${session}"
@@ -157,14 +163,14 @@ public class WGet extends AbstractMojo {
 
   /**
    * To look up Archiver/UnArchiver implementation
-   * 
+   *
    * @component
    */
   private ArchiverManager archiverManager;
 
   /**
    * For transfers
-   * 
+   *
    * @component
    */
   private WagonManager wagonManager;
@@ -172,7 +178,7 @@ public class WGet extends AbstractMojo {
 
   /**
    * Method call whent he mojo is executed for the first time.
-   * 
+   *
    * @throws MojoExecutionException
    *           if an error is occuring in this mojo.
    * @throws MojoFailureException
@@ -215,12 +221,60 @@ public class WGet extends AbstractMojo {
     // DO
     try
     {
-      if (outputFile.exists() && !overwrite)
+      boolean haveFile = outputFile.exists();
+      if (haveFile)
       {
+        boolean signatureMatch = true;
+        if (this.checkSignature)
+        {
+          String expectedDigest = null, algorithm = null;
+          if (this.md5 != null)
+          {
+            expectedDigest = this.md5;
+            algorithm = "MD5";
+          }
+
+          if (this.sha1 != null)
+          {
+            expectedDigest = this.sha1;
+            algorithm = "SHA1";
+          }
+
+          if (this.sha512 != null)
+          {
+            expectedDigest = this.sha512;
+            algorithm = "SHA-512";
+          }
+
+          if (expectedDigest != null)
+          {
+            try
+            {
+              SignatureUtils.verifySignature(outputFile, expectedDigest,
+                      MessageDigest.getInstance(algorithm));
+            }
+            catch (MojoFailureException e)
+            {
+              getLog().warn("The local version of file " + outputFile.getName() + " doesn't match the expected signature. " +
+                      "You should consider checking the specified signature is correctly set.");
+              signatureMatch = false;
+            }
+          }
+        }
+
         // TODO verify last modification date
-        getLog().info("File already exist, skipping");
+        if (!signatureMatch)
+        {
+          outputFile.delete();
+          haveFile = false;
+        }
+        else if (!overwrite)
+        {
+          getLog().info("File already exist, skipping");
+        }
       }
-      else
+
+      if (!haveFile)
       {
         File cached = cache.getArtifact(this.url, this.md5, this.sha1, this.sha512);
         if (!this.skipCache && cached != null && cached.exists())
@@ -247,7 +301,8 @@ public class WGet extends AbstractMojo {
                     MessageDigest.getInstance("SHA1"));
               }
               if (this.sha512 != null) {
-                SignatureUtils.verifySignature(outputFile, this.sha512, MessageDigest.getInstance("SHA-512"));
+                SignatureUtils.verifySignature(outputFile, this.sha512,
+                    MessageDigest.getInstance("SHA-512"));
               }
               done = true;
             }


### PR DESCRIPTION
In our projects we use the maven-download-plugin, but sometimes other developers changes the content of the files to download without changing the file name.
This patch allow the developer to put a new option in the pom file (checkSignature) to check the signature the already downloaded files, if don't match the file is removed and downloaded again.

Hope this could be merged in the main code... let me know if I have it done in the correct way... is my first maven plugin!!!