### PR TITLE
Fixes IT run issues on some environments

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -53,20 +53,25 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-invoker-plugin</artifactId>
+						<version>2.0.0</version>
 						<executions>
 							<execution>
 								<phase>integration-test</phase>
 								<goals>
+									<goal>install</goal>
 									<goal>run</goal>
 								</goals>
 								<configuration>
 									<projectsDirectory>src/it</projectsDirectory>
-									<cloneProjectsTo>target/it</cloneProjectsTo>
+									<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+									<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
 									<invokerPropertiesFile>invoke.properties</invokerPropertiesFile>
 									<preBuildHookScript>prepare.groovy</preBuildHookScript>
 									<postBuildHookScript>verify.groovy</postBuildHookScript>
 									<debug>true</debug>
-									<mavenOpts>-Dtesting.versionUnderTest=${version}</mavenOpts>
+									<environmentVariables>
+										<testing.versionUnderTest>${project.version}</testing.versionUnderTest>
+									</environmentVariables>
 								</configuration>
 							</execution>
 						</executions>


### PR DESCRIPTION
Errors and warnings encountered when running `mvn -Pits clean verify`:

- Added `install` goal (and `localRepositoryPath` configuration) for `maven-invoker-plugin`. Without this goal, the ITs are run against the SNAPSHOT version downloaded from the snapshot repository rather than the local built version.
- Using `environmentVariables` to pass the `testing.versionUnderTest` property to the IT POMs, rather than `mavenOpts`; as the latter fails if someone has `MAVEN_OPTS` defined in a `.mavenrc` file.
- Added version to the `maven-invoker-plugin` to avoid Maven warning.
- Using `${project.version}` rather than `${version}` to avoid Maven warning.