### PR TITLE
Make plugin compatible with m2e

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -129,12 +129,17 @@
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
-			<version>1.5.4</version>
+			<version>1.5.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-provider-api</artifactId>
 			<version>2.5</version>
+		</dependency>
+		<dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>0.0.7</version>
 		</dependency>
 	</dependencies>
 	<!-- Reporting -->

--- a/download-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/download-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,33 @@
+<!--
+  Copyright 2016 Download Plugin for Maven
+  
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+  Unless required by applicable law or agreed to in writing, software 
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  License for the specific language governing permissions and limitations 
+  under the License.
+-->
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>wget</goal>
+                    <goal>artifact</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <!-- It is OK to run this on incremental; the plugin uses a cache -->
+                    <runOnIncremental>true</runOnIncremental>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
## M2Eclipse Compatibility

Changes made per [M2Eclipse | Making Maven Plugins Compatible](https://www.eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html)

This change allows Maven projects using this project to be developed in Eclipse (with m2e) without messing around with m2e exclude directives. This also allows projects which depend on this plugin for compile/test to succeed to work from Eclipse, without having to drop in and out of the CLI.
## Change Summary
- Added lifecycle mapping metadata
- Use `BuildContext` (from `plexus-build-api`) to indicate file changes and during incremental builds
- Update `plexus-utils` version; required to work with `plexus-build-api` version 0.0.7

Feedback, comments welcome.
### Missing IT

I would have like to have added an IT, but have not been able to figure out how to get the `DefaultBuildContext` implementation (or a different one) to switch between full and incremental build easily through the invoker plugin.
