### PR TITLE
#72 Start DownloadCache refactoring

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -138,18 +138,6 @@
 			<version>4.0-beta2</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.plugin-testing</groupId>
-			<artifactId>maven-plugin-testing-harness</artifactId>
-			<version>1.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-archiver</artifactId>
 			<version>3.0.1</version>
@@ -164,6 +152,26 @@
 			<artifactId>wagon-provider-api</artifactId>
 			<version>2.5</version>
 		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+        </dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-testing</groupId>
+			<artifactId>maven-plugin-testing-harness</artifactId>
+			<version>1.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 	<!-- Reporting -->
 	<reporting>

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/SignatureUtils.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/SignatureUtils.java
@@ -29,14 +29,14 @@ import org.apache.maven.plugin.MojoFailureException;
  */
 public class SignatureUtils {
 
-    static void verifySignature(File file, String expectedDigest, MessageDigest digest) throws Exception {
+    public static void verifySignature(File file, String expectedDigest, MessageDigest digest) throws Exception {
         String actualDigestHex = SignatureUtils.computeSignatureAsString(file, digest);
         if (!actualDigestHex.equals(expectedDigest)) {
             throw new MojoFailureException("Not same digest as expected: expected <" + expectedDigest + "> was <" + actualDigestHex + ">");
         }
     }
 
-    static String computeSignatureAsString(File file,
+    public static String computeSignatureAsString(File file,
         MessageDigest digest) throws IOException {
         InputStream fis = new FileInputStream(file);
         byte[] buffer = new byte[1024];
@@ -52,15 +52,15 @@ public class SignatureUtils {
         return new String(Hex.encodeHex(actualDigest));
     }
 
-    static String getMD5(File file) throws IOException, NoSuchAlgorithmException {
+    public static String getMD5(File file) throws IOException, NoSuchAlgorithmException {
         return computeSignatureAsString(file, MessageDigest.getInstance("MD5"));
     }
 
-    static String getSHA1(File file) throws IOException, NoSuchAlgorithmException {
+    public static String getSHA1(File file) throws IOException, NoSuchAlgorithmException {
         return computeSignatureAsString(file, MessageDigest.getInstance("SHA1"));
     }
 
-    static String getSHA512(File file) throws IOException, NoSuchAlgorithmException {
+    public static String getSHA512(File file) throws IOException, NoSuchAlgorithmException {
         return computeSignatureAsString(file, MessageDigest.getInstance("SHA-512"));
     }
 }

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -14,6 +14,7 @@
  */
 package com.googlecode.download.maven.plugin.internal;
 
+import com.googlecode.download.maven.plugin.internal.cache.DownloadCache;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
@@ -49,7 +50,7 @@ public class WGet extends AbstractMojo {
      * Represent the URL to fetch information from.
      */
     @Parameter(property = "download.url", required = true)
-    private String url;
+    private URL url;
 
     /**
      * Flag to overwrite the file by redownloading it
@@ -183,7 +184,7 @@ public class WGet extends AbstractMojo {
         // PREPARE
         if (this.outputFileName == null) {
             try {
-                this.outputFileName = new File(new URL(this.url).getFile()).getName();
+                this.outputFileName = new File(this.url.getFile()).getName();
             } catch (Exception ex) {
                 throw new MojoExecutionException("Invalid URL", ex);
             }
@@ -305,9 +306,10 @@ public class WGet extends AbstractMojo {
 
 
     private void doGet(File outputFile) throws Exception {
-        String[] segments = this.url.split("/");
+        String urlStr = this.url.toString();
+        String[] segments = urlStr.split("/");
         String file = segments[segments.length - 1];
-        String repoUrl = this.url.substring(0, this.url.length() - file.length() - 1);
+        String repoUrl = urlStr.substring(0, urlStr.length() - file.length() - 1);
         Repository repository = new Repository(repoUrl, repoUrl);
 
         Wagon wagon = this.wagonManager.getWagon(repository.getProtocol());

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2012, Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.download.maven.plugin.internal.cache;
+
+import com.googlecode.download.maven.plugin.internal.SignatureUtils;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * A class representing a download cache
+ * @author Mickael Istria (Red Hat Inc)
+ *
+ */
+public class DownloadCache {
+
+	private final File basedir;
+    private final FileIndex index;
+
+	public DownloadCache(File cacheDirectory) {
+        DownloadCache.createIfNeeded(cacheDirectory);
+        this.index = new FileBackedIndex(cacheDirectory);
+        this.basedir = cacheDirectory;
+    }
+
+	private String getEntry(URL url, String md5, String sha1, String sha512) throws Exception {
+		if (!this.index.contains(url)) {
+			return null;
+		}
+		final String res = this.index.get(url);
+		File resFile = new File(this.basedir, res);
+		if (!resFile.isFile()) {
+			return null;
+		}
+		if (md5 != null && !md5.equals(SignatureUtils.getMD5(resFile))) {
+			return null;
+		}
+		if (sha1 != null && !sha1.equals(SignatureUtils.getSHA1(resFile))) {
+			return null;
+		}
+		if (sha512 != null && !sha512.equals(SignatureUtils.getSHA512(resFile))) {
+			return null;
+		}
+		return res;
+	}
+
+	/**
+	 * Get a File in the download cache. If no cache for this URL, or
+	 * if expected signatures don't match cached ones, returns null.
+	 * available in cache,
+	 * @param url URL of the file
+	 * @param md5 MD5 signature to verify file. Can be null =&gt; No check
+	 * @param sha1 Sha1 signature to verify file. Can be null =&gt; No check
+	 * @return A File when cache is found, null if no available cache
+	 */
+    public File getArtifact(URL url, String md5, String sha1, String sha512) throws Exception {
+		String res = getEntry(url, md5, sha1, sha512);
+		if (res != null) {
+			return new File(this.basedir, res);
+		}
+		return null;
+	}
+
+    public void install(URL url, File outputFile, String md5, String sha1, String sha512) throws Exception {
+		if (md5 == null) {
+			md5 = SignatureUtils.computeSignatureAsString(outputFile, MessageDigest.getInstance("MD5"));
+		}
+		if (sha1 == null) {
+			sha1 = SignatureUtils.computeSignatureAsString(outputFile, MessageDigest.getInstance("SHA1"));
+		}
+		if (sha512 == null) {
+			sha512 = SignatureUtils.computeSignatureAsString(outputFile, MessageDigest.getInstance("SHA-512"));
+		}
+		String entry = getEntry(url, md5, sha1, sha512);
+		if (entry != null) {
+			return; // entry already here
+		}
+		String fileName = outputFile.getName() + '_' + DigestUtils.md5Hex(url.toString());
+		Files.copy(outputFile.toPath(), new File(this.basedir, fileName).toPath(), StandardCopyOption.REPLACE_EXISTING);
+		// update index
+		this.index.put(url, fileName);
+	}
+
+    private static void createIfNeeded(final File basedir) {
+        if (!basedir.exists()) {
+            basedir.mkdirs();
+        } else if (!basedir.isDirectory()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Cannot use %s as cache directory: file is already exist",
+                    basedir
+                )
+            );
+        }
+    }
+}

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
@@ -1,0 +1,128 @@
+package com.googlecode.download.maven.plugin.internal.cache;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.RandomAccessFile;
+import java.net.URL;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Binary file backed index.
+ * @author Paul Polishchuk
+ * @since 1.3.1
+ */
+final class FileBackedIndex implements FileIndex {
+
+    private final Map<URL, String> index = new HashMap<>();
+    private final File storage;
+
+    /**
+     * Creates index backed by file "index.ser" in baseDir.
+     * Throws runtime exceptions if baseDir does not exist, not a directory
+     * or file can't be created in it.
+     * @param baseDir directory where the index file should be stored.
+     */
+    FileBackedIndex(final File baseDir) {
+        if (!baseDir.isDirectory()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Cannot use %s as cache directory: not exist or not a directory",
+                    baseDir.getAbsolutePath()
+                )
+            );
+        }
+        final File store = new File(baseDir, "index.ser");
+        if (store.exists()) {
+            this.loadFrom(store);
+        } else {
+            FileBackedIndex.create(store);
+        }
+        this.storage = store;
+    }
+
+    @Override
+    public void put(final URL url, final String path) {
+        this.index.put(url, path);
+        this.save();
+    }
+
+    @Override
+    public boolean contains(final URL url) {
+        this.loadFrom(this.storage);
+        return this.index.containsKey(url);
+    }
+
+    @Override
+    public String get(final URL url) {
+        if (this.contains(url)) {
+            return this.index.get(url);
+        }
+        throw new IllegalStateException(
+            "Cache miss. Check for existence with FileIndex#contains before"
+        );
+    }
+
+    /**
+     * Create storage file.
+     * @param store File to be created.
+     */
+    private static void create(final File store) {
+        try {
+            if (!store.createNewFile()) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Failed to create index storage file %s",
+                        store.getAbsolutePath()
+                    )
+                );
+            }
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Loads index from the file storage replacing all in-memory entries.
+     * @param store file where index is persisted.
+     */
+    @SuppressWarnings("unchecked")
+    private void loadFrom(final File store) {
+        if (store.length() != 0L) {
+            try (
+                final RandomAccessFile file = new RandomAccessFile(store, "r");
+                final FileChannel channel = file.getChannel();
+                final FileLock lock = channel.lock(0L, Long.MAX_VALUE, true);
+                final ObjectInputStream deserialize = new ObjectInputStream(new FileInputStream(store))
+            ) {
+                this.index.clear();
+                this.index.putAll((Map<URL, String>) deserialize.readObject());
+            } catch (final IOException | ClassNotFoundException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
+
+    /**
+     * Saves current im-memory index to file based storage.
+     */
+    private void save() {
+        try (
+            final FileOutputStream file = new FileOutputStream(this.storage);
+            final ObjectOutput res = new ObjectOutputStream(file);
+            final FileChannel channel = file.getChannel();
+            final FileLock lock = channel.lock()
+        ) {
+            res.writeObject(this.index);
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileIndex.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileIndex.java
@@ -1,0 +1,37 @@
+package com.googlecode.download.maven.plugin.internal.cache;
+
+import java.net.URL;
+
+/**
+ * Convenient map to search for the path where file is locally stored
+ * by url of the resource the file was downloaded from.
+ * Implementations should not read/write file bodies using stored paths.
+ *
+ * @author Paul Polishchuk
+ * @since 1.3.1
+ */
+interface FileIndex {
+
+    /**
+     * Adds given path to the index using url parameter as a key.
+     * @param url index key
+     * @param path index value
+     */
+    void put(URL url, String path);
+
+    /**
+     * Check if a path associated with the url key in the index.
+     * <p>Use this method before actually trying to get value.
+     * @param url index key
+     * @return true if some path associated with given key
+     */
+    boolean contains(URL url);
+
+    /**
+     * Gets stored value by the key.
+     * @param url index key
+     * @return path by given url key; never NULL
+     * @throws IllegalStateException in case key is not found
+     */
+    String get(URL url);
+}

--- a/download-maven-plugin/src/test/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndexTest.java
+++ b/download-maven-plugin/src/test/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndexTest.java
@@ -1,0 +1,54 @@
+package com.googlecode.download.maven.plugin.internal.cache;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@code FileBackedIndex}.
+ * @author Paul Polishchuk
+ * @since 1.3.1
+ */
+public final class FileBackedIndexTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void putCheckAndGet() throws IOException {
+        final FileIndex index = new FileBackedIndex(this.tmp.newFolder("cacheDir"));
+        final URL url = new URL("http://localhost/first/url");
+        final String path = "some path";
+        index.put(url, path);
+        MatcherAssert.assertThat(index.contains(url), Matchers.is(true));
+        MatcherAssert.assertThat(index.get(url), Matchers.is(path));
+    }
+
+    @Test
+    public void checkForNotExistent() throws IOException {
+        final FileIndex index = new FileBackedIndex(this.tmp.newFolder("cacheDir"));
+        MatcherAssert.assertThat(
+            index.contains(new URL("http://localhost/not/exist")), Matchers.is(false)
+        );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throwsIfGetNotExistent() throws IOException {
+        new FileBackedIndex(this.tmp.newFolder("cacheDir")).get(new URL("http://localhost/not/exist"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIfBaseNotExist() {
+        new FileBackedIndex(new File("notExist"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIfBaseNotADir() throws IOException {
+        new FileBackedIndex(this.tmp.newFile("notADir"));
+    }
+}


### PR DESCRIPTION
#72 Start `DownloadCache` refactoring
The main reason - separation of concerns.
Benefit - understandable and maintainable code, which is easy to test with unit test.
Done - extracted Index management code from the Cache.
ToBeDone (next) - separate signature management code from the cache.

@mickaelistria please, take a look and tell what do you think?

