### PR TITLE
Add support for http headers/parameters

### DIFF
--- a/download-maven-plugin/pom.xml
+++ b/download-maven-plugin/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.0-beta2</version>
+			<version>4.1.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/ConsoleDownloadMonitor.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/ConsoleDownloadMonitor.java
@@ -1,5 +1,10 @@
 package com.googlecode.download.maven.plugin.internal;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.commons.io.FileUtils;
+
 /*
  * Copyright 2001-2005 The Apache Software Foundation.
  *
@@ -41,52 +46,85 @@ final class ConsoleDownloadMonitor implements TransferListener {
 
     @Override
     public void transferInitiated(final TransferEvent event) {
+        transferInitiated(event.getResource().getName(), event.getWagon().getRepository().getUrl(), event.getRequestType());
+    }
+
+    /**
+     * Display the transfer started message
+     * @param downloadUrl full download url to file
+     * @param requestType One of values returnable by {@link TransferEvent#getRequestType()}
+     */
+	public void transferInitiated(final String resourceName, final String downloadUrl, final int requestType) {
         this.completed = 0L;
         this.log.info(
             String.format(
                 "%s: %s/%s",
-                event.getRequestType() == TransferEvent.REQUEST_PUT ? "Uploading" : "Downloading",
-                event.getWagon().getRepository().getUrl(),
-                event.getResource().getName()
+                requestType == TransferEvent.REQUEST_PUT ? "Uploading" : "Downloading",
+                downloadUrl,
+                resourceName
             )
         );
-    }
+	}
 
     @Override
     public void transferStarted(final TransferEvent event) {
         // This space left intentionally blank
     }
 
-    @Override
-    public void transferProgress(final TransferEvent event, final byte[] buffer, final int length) {
-        final long total = event.getResource().getContentLength();
-        this.completed += (long) length;
-        final String totalInUnits;
-        final long completedInUnits;
-        if (total >= KBYTE) {
-            totalInUnits = total == WagonConstants.UNKNOWN_LENGTH ? "?" : (total / KBYTE) + "K";
-            completedInUnits = this.completed / KBYTE;
-        } else {
-            totalInUnits = total == WagonConstants.UNKNOWN_LENGTH ? "?" : total + "b";
-            completedInUnits = this.completed;
-        }
-        this.log.info(String.format(PROGRESS_FORMAT, completedInUnits, totalInUnits));
-    }
+
+	@Override
+	public void transferProgress(TransferEvent transferEvent, byte[] buffer, int length) {
+		final long total = transferEvent.getResource().getContentLength();
+		this.completed += (long) length;
+		transferProgress(completed, total);
+	}
+    /**
+     * Output transfer progress message in a pluggable way
+     * @param total
+     */
+	public void transferProgress(final long alreadyDownloaded, final long total) {
+		log.info(getTransferMessage(alreadyDownloaded, total));
+	}
+
+	/**
+	 * Create a transfer message from total read size
+	 * @param alreadyDownloaded
+	 * @param total
+	 * @return
+	 */
+	private String getTransferMessage(final long alreadyDownloaded, final long total) {
+		final String message = null;
+		return FileUtils.byteCountToDisplaySize(alreadyDownloaded) + "/" +
+						( total == WagonConstants.UNKNOWN_LENGTH ? "?" : FileUtils.byteCountToDisplaySize(total) ) +
+			    "\r";
+	}
 
     @Override
-    public void transferCompleted(final TransferEvent event) {
-        final long length = event.getResource().getContentLength();
-        if (length != (long) WagonConstants.UNKNOWN_LENGTH) {
+	public void transferCompleted( final TransferEvent transferEvent )
+    {
+        final long contentLength = transferEvent.getResource().getContentLength();
+        final int requestType = transferEvent.getRequestType();
+        transferCompleted(contentLength, requestType);
+    }
+
+    /**
+     * Output transfer terminated message
+     * @param contentLength total content length
+     * @param requestType One of values returnable by {@link TransferEvent#getRequestType()}
+     */
+	public void transferCompleted(final long length, final int requestType) {
+		if ( length != WagonConstants.UNKNOWN_LENGTH )
+        {
             this.log.info(
-                String.format(
-                    "%s %s",
-                    event.getRequestType() == TransferEvent.REQUEST_PUT ? "uploaded" : "downloaded",
-                    length >= KBYTE ? (length / KBYTE) + "K" : length + "b"
-                )
-            );
+                    String.format(
+                        "%s %s",
+                        requestType == TransferEvent.REQUEST_PUT ? "uploaded" : "downloaded",
+                        length >= KBYTE ? (length / KBYTE) + "K" : length + "b"
+                    )
+                );
         }
-    }
-
+	}
+	
     @Override
     public void transferError(final TransferEvent event) {
         this.log.error(event.getException());
@@ -96,4 +134,69 @@ final class ConsoleDownloadMonitor implements TransferListener {
     public void debug(final String message) {
         this.log.debug(message);
     }
+
+    /**
+     * Decorate an output stream by writing regularly the download progress.
+     * Notice publishing to outputstream is done once each second, by using a simple time check.
+     * Maybe poor, but allow me that laziness for the sake of not one more thread.
+     * @param openOutputStream
+     * @return
+     */
+	public OutputStream decorate(final OutputStream openOutputStream, final long totalSize) {
+		return new OutputStream() {
+
+			/**
+			 * Number of written bytes
+			 */
+			private int written = 0;
+
+			/**
+			 * Time last message was written at
+			 */
+			private long lastMessageWasWrittenAt;
+
+			/**
+			 * Write something if one second (at least) has elapsed since last message
+			 */
+			private void maybeWrite() {
+
+				final long timeInSeconds = System.currentTimeMillis()/1000;
+				if(timeInSeconds-lastMessageWasWrittenAt>0) {
+					transferProgress(written, totalSize);
+					lastMessageWasWrittenAt = timeInSeconds;
+				}
+			}
+
+			@Override
+			public void write(final int b) throws IOException {
+				openOutputStream.write(b);
+				written++;
+				maybeWrite();
+			}
+
+			@Override
+			public void write(final byte[] abyte0) throws IOException {
+				openOutputStream.write(abyte0);
+				written += abyte0.length;
+				maybeWrite();
+			}
+
+			@Override
+			public void write(final byte[] abyte0, final int offset, final int length) throws IOException {
+				openOutputStream.write(abyte0, offset, length);
+				written += length;
+				maybeWrite();
+			}
+
+			@Override
+			public void flush() throws IOException {
+				openOutputStream.flush();
+			}
+
+			@Override
+			public void close() throws IOException {
+				openOutputStream.close();
+			}
+		};
+	}
 }

--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -14,11 +14,27 @@
  */
 package com.googlecode.download.maven.plugin.internal;
 
-import com.googlecode.download.maven.plugin.internal.cache.DownloadCache;
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -28,16 +44,14 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
-import org.apache.maven.wagon.Wagon;
-import org.apache.maven.wagon.authentication.AuthenticationInfo;
-import org.apache.maven.wagon.proxy.ProxyInfo;
-import org.apache.maven.wagon.repository.Repository;
+import org.apache.maven.wagon.events.TransferEvent;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.util.StringUtils;
+
+import com.googlecode.download.maven.plugin.internal.cache.DownloadCache;
 
 /**
  * Will download a file from a web site using the standard HTTP protocol.
@@ -100,13 +114,13 @@ public class WGet extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean unpack;
 
-    /**
+	/**
      * Server Id from settings file to use for authentication
      * Only one of serverId or (username/password) may be supplied
      */
     @Parameter
     private String serverId;
-    
+
     /**
      * Custom username for the download
      */
@@ -177,37 +191,55 @@ public class WGet extends AbstractMojo {
     @Parameter(defaultValue = "${settings}", readonly = true, required = true)
     private Settings settings;
 
-    /**
-     * Method call whent he mojo is executed for the first time.
-     * @throws MojoExecutionException if an error is occuring in this mojo.
-     * @throws MojoFailureException if an error is occuring in this mojo.
-     */
-    public void execute() throws MojoExecutionException, MojoFailureException {
+	/**
+	 * Map of HTTP parameters to be used to download content. These properties are to be given as
+	 * &lt;httpParameters&gt;
+	 * 	&lt;aParameterName&gt;aParameterValue&lt;/aParameterName&gt;
+	 * &lt;httpParameters&gt;
+	 */
+    @Parameter(property = "parameters")
+	private final Map<String, String> parameters = new HashMap<>();
+
+	/**
+	 * Map of HTTP headers to be used to download content. These properties are to be given as
+	 * &lt;httpHeaders&gt;
+	 * 	&lt;aHeaderName&gt;aParameterValue&lt;/aHeaderName&gt;
+	 * &lt;/httpHeaders&gt;
+	 */
+    @Parameter(property = "headers")
+	private final Map<String, String> headers = new HashMap<>();
+
+	/**
+	  * Method call whent he mojo is executed for the first time.
+	  * @throws MojoExecutionException if an error is occuring in this mojo.
+	  * @throws MojoFailureException if an error is occuring in this mojo.
+	  */
+	public void execute() throws MojoExecutionException, MojoFailureException {
         if (this.skip) {
-            getLog().info("maven-download-plugin:wget skipped");
-            return;
-        }
-        
+			getLog().info("maven-download-plugin:wget skipped");
+			return;
+		}
+
         if (StringUtils.isNotBlank(serverId) && (StringUtils.isNotBlank(username) || StringUtils.isNotBlank(password))) {
             throw new MojoExecutionException("Specify either serverId or username/password, not both");
         }
-        
+
         if (settings == null) {
             getLog().warn("settings is null");
         }
         getLog().debug("Got settings");
-        if (retries < 1) {
-            throw new MojoFailureException("retries must be at least 1");
-        }
+		if (retries < 1) {
+			throw new MojoFailureException("retries must be at least 1");
+		}
 
-        // PREPARE
+		// PREPARE
         if (this.outputFileName == null) {
-            try {
+			try {
                 this.outputFileName = new File(this.uri.toURL().getFile()).getName();
             } catch (Exception ex) {
-                throw new MojoExecutionException("Invalid URL", ex);
-            }
-        }
+				throw new MojoExecutionException("Invalid URL", ex);
+			}
+		}
         if (this.cacheDirectory == null) {
             this.cacheDirectory = new File(this.session.getLocalRepository()
                 .getBasedir(), ".cache/download-maven-plugin");
@@ -217,8 +249,8 @@ public class WGet extends AbstractMojo {
         this.outputDirectory.mkdirs();
         File outputFile = new File(this.outputDirectory, this.outputFileName);
 
-        // DO
-        try {
+		// DO
+		try {
             boolean haveFile = outputFile.exists();
             if (haveFile) {
                 boolean signatureMatch = true;
@@ -273,7 +305,8 @@ public class WGet extends AbstractMojo {
                     boolean done = false;
                     while (!done && this.retries > 0) {
                         try {
-                            doGet(outputFile);
+                            doGet(uri.toURL(), outputFile,
+                            		parameters, headers, retries);
                             if (this.md5 != null) {
                                 SignatureUtils.verifySignature(outputFile, this.md5,
                                     MessageDigest.getInstance("MD5"));
@@ -323,50 +356,95 @@ public class WGet extends AbstractMojo {
         outputFile.delete();
     }
 
-
-    private void doGet(File outputFile) throws Exception {
-        String urlStr = this.uri.toString();
-        String[] segments = urlStr.split("/");
-        String file = segments[segments.length - 1];
-        String repoUrl = urlStr.substring(0, urlStr.length() - file.length() - 1);
-        Repository repository = new Repository(repoUrl, repoUrl);
-
-        Wagon wagon = this.wagonManager.getWagon(repository.getProtocol());
-        if (readTimeOut > 0) {
-            wagon.setReadTimeout(readTimeOut);
-            getLog().info(
-                "Read Timeout is set to " + readTimeOut + " milliseconds (apprx "
-                    + Math.round(readTimeOut * 1.66667e-5) + " minutes)");
-        }
+	/**
+	 * Perform the get operation and outputs a bunch of debug messages
+	 * @param source the source to download data from
+	 * @param outputFile the output destination
+	 * @param parameters http parameters used for that request
+	 * @param headers http headers used for that request
+	 * @param retries number of times that query will be retried
+	 * @throws Exception
+	 */
+	private void doGet(final URL source, final File outputFile, final Map<String, String> parameters, final Map<String, String> headers, final int retries) throws Exception {
         ConsoleDownloadMonitor downloadMonitor = null;
-        if (this.session.getSettings().isInteractiveMode()) {
-            downloadMonitor = new ConsoleDownloadMonitor(this.getLog());
-            wagon.addTransferListener(downloadMonitor);
+        if (session.getSettings().isInteractiveMode()) {
+            downloadMonitor = new ConsoleDownloadMonitor(getLog());
         }
+		final HttpGet getRequest = new HttpGet(source.toURI());
+		// putting parameters in game
+		for(final Map.Entry<String, String> p : parameters.entrySet()) {
+			getRequest.getParams().setParameter(p.getKey(), p.getValue());
+		}
+		// and headers next to them
+		for(final Map.Entry<String, String> h : headers.entrySet()) {
+			getRequest.addHeader(h.getKey(), h.getValue());
+		}
+		if(getLog().isDebugEnabled()) {
+			final StringBuilder sOut = new StringBuilder();
+			sOut.append("running ").append(getRequest).append("\n");
+			sOut.append("query headers :\n").append(appendHeaders(getRequest.getAllHeaders()));
+			sOut.append("query parameters can't be obtained, sorry\n");
+			getLog().debug(sOut);
+		}
+		// Creating client on-demand to allow easy retry
+		final HttpClient client = getHttpClient(retries);
+		downloadMonitor.transferInitiated(outputFile.getName(), source.toString(), TransferEvent.REQUEST_GET);
+		final HttpResponse response = client.execute(getRequest);
+		// Put some more log info about response before to consume content
+		if(getLog().isDebugEnabled()) {
+			final StringBuilder sOut = new StringBuilder("query executed with result\n");
+			final StatusLine status = response.getStatusLine();
+			sOut.append(status.getProtocolVersion().toString()).append("\t").append(status.getStatusCode()).append(" ").append(status.getReasonPhrase()).append("\n");
+			sOut.append("response headers :\n");
+			sOut.append(appendHeaders(response.getAllHeaders()));
+			getLog().debug(sOut);
+		}
+		// now make sure result was OK (if not an exception will be thrown)
+		final int statusCode = response.getStatusLine().getStatusCode();
+		if(statusCode>=200 && statusCode<300) {
+			final HttpEntity entity = response.getEntity();
+			if(getLog().isDebugEnabled()) {
+				final StringBuilder sOut = new StringBuilder("query entity content is\n");
+				sOut.append(appendHeaders(new Header[] {entity.getContentType(), entity.getContentEncoding()}));
+			}
+			// Now read entity content
+			final InputStream stream = entity.getContent();
+			final BufferedInputStream bufferedInput = new BufferedInputStream(stream);
+			outputFile.createNewFile();
+			final OutputStream openOutputStream = downloadMonitor.decorate(FileUtils.openOutputStream(outputFile), entity.getContentLength());
+			try {
+				IOUtils.copy(bufferedInput,openOutputStream);
+			} finally {
+				downloadMonitor.transferCompleted(entity.getContentLength(), TransferEvent.REQUEST_GET);
+				openOutputStream.close();
+				bufferedInput.close();
+			}
+		} else {
+			throw new UnsupportedOperationException("server sent status code "+statusCode+" which we do not support");
+		}
+	}
 
-        AuthenticationInfo authenticationInfo = new AuthenticationInfo();
-        if (StringUtils.isNotBlank(username)) {
-            getLog().debug("providing custom authentication");
-            getLog().debug("username: " + username + " and password: ***");
-            authenticationInfo.setUserName(username);
-            authenticationInfo.setPassword(password);
-        } else if (StringUtils.isNotBlank(serverId)) {
-            getLog().debug("providing custom authentication for " + serverId);
-            Server server = settings.getServer(serverId);
-            if (server == null)
-                throw new MojoExecutionException(String.format("Server %s not found", serverId));
-            getLog().debug(String.format("serverId %s supplies username: %s and password: ***",  serverId, server.getUsername() ));
-            authenticationInfo.setUserName(server.getUsername());
-            authenticationInfo.setPassword(server.getPassword());
-        }
+	/**
+	 * Construct the http client with the specified number of retries
+	 * @param retries number of times the query will be re-send to server
+	 * @return a working HTTP client
+	 */
+	private HttpClient getHttpClient(final int retries) {
+		final DefaultHttpClient returned = new DefaultHttpClient();
+		returned.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(retries, false));
+		return returned;
+	}
 
-        ProxyInfo proxyInfo = this.wagonManager.getProxy(repository.getProtocol());
-
-        wagon.connect(repository, authenticationInfo, proxyInfo);
-        wagon.get(file, outputFile);
-        wagon.disconnect();
-        if (downloadMonitor != null) {
-            wagon.removeTransferListener(downloadMonitor);
-        }
-    }
+	/**
+	 * Append headers to a string, for easier reading
+	 * @param headers
+	 * @return
+	 */
+	private StringBuilder appendHeaders(final Header[] headers) {
+		final StringBuilder sOut = new StringBuilder();
+		for(final Header h : headers) {
+			sOut.append(h).append("\n");
+		}
+		return sOut;
+	}
 }


### PR DESCRIPTION
This pull request fixes #8 by replacing maven wagon by http client.
Unfortunatly, this impacts both `WGet` task and `ConsoleDownloadMonitor` which now uses information from http client stream.
This way, it is possible to inject during query construction the good headers and parameters.