### PR TITLE
minor fix for overwrite and file exists

### DIFF
--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -252,7 +252,7 @@ public class WGet extends AbstractMojo {
                 }
 
                 // TODO verify last modification date
-                if (!signatureMatch) {
+                if (!signatureMatch || (overwrite && haveFile)) {
                     outputFile.delete();
                     haveFile = false;
                 } else if (!overwrite) {
@@ -268,6 +268,7 @@ public class WGet extends AbstractMojo {
                 File cached = cache.getArtifact(this.uri, this.md5, this.sha1, this.sha512);
                 if (!this.skipCache && cached != null && cached.exists()) {
                     getLog().info("Got from cache: " + cached.getAbsolutePath());
+                    getLog().info("To download a fresh copy pass -Ddownload.plugin.skipCache=true to the maven build");
                     Files.copy(cached.toPath(), outputFile.toPath());
                 } else {
                     boolean done = false;


### PR DESCRIPTION
minor fix for overwrite and file exists.  Currently it will fail because it can't overwrite the file.  Also add an info line to inform users how to download a fresh copy.