### PR TITLE
allow unpacking from command-line

### DIFF
--- a/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/download-maven-plugin/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -99,7 +99,7 @@ public class WGet extends AbstractMojo {
     /**
      * Whether to unpack the file in case it is an archive (.zip)
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(property = "download.unpack", defaultValue = "false")
     private boolean unpack;
 
     /**


### PR DESCRIPTION
Small change to allow using the plugin from the command line to download and unpack a zip file.

This is going to be useful in systems that have Maven but don't have unzip installed (such as Jenkins nodes).