### PR TITLE
Handle file naming when HTTP Redirects occur

### DIFF
--- a/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
@@ -24,15 +24,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
+import org.apache.http.*;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.protocol.HttpContext;
 
 /**
  * File requester that can download resources over HTTP transport using Apache HttpClient 4.x.
@@ -84,6 +81,18 @@ public class HttpFileRequester {
 
                     if (actualOutputFile == null) {
                         actualOutputFile = outputFile;
+                    }
+
+                    // check if we were redirected, but we found the new location in the cache via {@link WGet#RedirectIfNotInCache}
+                    switch (response.getStatusLine().getStatusCode()) {
+                        case HttpStatus.SC_MOVED_TEMPORARILY:
+                        case HttpStatus.SC_MOVED_PERMANENTLY:
+                        case HttpStatus.SC_TEMPORARY_REDIRECT:
+                        case HttpStatus.SC_SEE_OTHER:
+                            return actualOutputFile;
+
+                        default:
+                            // continue
                     }
 
                     progressReport.initiate(uri, entity.getContentLength());

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -258,9 +258,11 @@ public class WGet extends AbstractMojo {
         }
 
         // PREPARE
+        boolean fixedOutputFileName = true;
         if (this.outputFileName == null) {
             try {
                 this.outputFileName = new File(this.uri.toURL().getFile()).getName();
+                fixedOutputFileName = false;
             } catch (Exception ex) {
                 throw new MojoExecutionException("Invalid URL", ex);
             }
@@ -330,7 +332,7 @@ public class WGet extends AbstractMojo {
                     boolean done = false;
                     while (!done && this.retries > 0) {
                         try {
-                            doGet(outputFile);
+                            outputFile = doGet(fixedOutputFileName, outputFile);
                             if (this.md5 != null) {
                                 SignatureUtils.verifySignature(outputFile, this.md5,
                                     MessageDigest.getInstance("MD5"));
@@ -395,7 +397,7 @@ public class WGet extends AbstractMojo {
     }
 
 
-    private void doGet(final File outputFile) throws Exception {
+    private File doGet(final boolean fixedOutputFileName, final File outputFile) throws Exception {
         final RequestConfig requestConfig;
         if (readTimeOut > 0) {
             getLog().info(
@@ -476,7 +478,7 @@ public class WGet extends AbstractMojo {
             clientContext.setCredentialsProvider(credentialsProvider);
         }
 
-        fileRequester.download(this.uri, outputFile, clientContext);
+        return fileRequester.download(this.uri, fixedOutputFileName, outputFile, clientContext);
     }
 
     private String decrypt(String str, String server) {


### PR DESCRIPTION
Before this PR when getting a resource from a URL, if a `<fileOutputName>` was not configured, the resultant file would be named based on the name of the remote resource configured in `<url>`. 

However if the URL leads to a HTTP redirect, then the name of the remote resource changes as we are redirected one or more times. This PR accounts for HTTP redirects, by changing the name of the output file only when:
1. A `<fileOutputName>` is not explicitly configured,
2. and, a HTTP redirect is detected which leads to a differently named resource.