### PR TITLE
Fix an issue with unpacking gzip files

### DIFF
--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -54,6 +54,7 @@ import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.codehaus.plexus.archiver.UnArchiver;
+import org.codehaus.plexus.archiver.gzip.GZipUnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.util.StringUtils;
@@ -374,7 +375,11 @@ public class WGet extends AbstractMojo {
     private void unpack(File outputFile) throws NoSuchArchiverException {
         UnArchiver unarchiver = this.archiverManager.getUnArchiver(outputFile);
         unarchiver.setSourceFile(outputFile);
-        unarchiver.setDestDirectory(this.outputDirectory);
+        if (unarchiver instanceof GZipUnArchiver) {
+            unarchiver.setDestFile(new File(this.outputDirectory, this.outputFileName.replaceFirst("(.+)\\.gz(?:ip)?$", "$1")));
+        } else {
+            unarchiver.setDestDirectory(this.outputDirectory);
+        }
         unarchiver.extract();
         outputFile.delete();
     }

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -54,9 +54,12 @@ import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.codehaus.plexus.archiver.UnArchiver;
+import org.codehaus.plexus.archiver.bzip2.BZip2UnArchiver;
 import org.codehaus.plexus.archiver.gzip.GZipUnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
+import org.codehaus.plexus.archiver.snappy.SnappyUnArchiver;
+import org.codehaus.plexus.archiver.xz.XZUnArchiver;
 import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.plexus.build.incremental.BuildContext;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
@@ -375,13 +378,20 @@ public class WGet extends AbstractMojo {
     private void unpack(File outputFile) throws NoSuchArchiverException {
         UnArchiver unarchiver = this.archiverManager.getUnArchiver(outputFile);
         unarchiver.setSourceFile(outputFile);
-        if (unarchiver instanceof GZipUnArchiver) {
-            unarchiver.setDestFile(new File(this.outputDirectory, this.outputFileName.replaceFirst("(.+)\\.gz(?:ip)?$", "$1")));
+        if (isFileUnArchiver(unarchiver)) {
+            unarchiver.setDestFile(new File(this.outputDirectory, outputFileName.substring(0, outputFileName.lastIndexOf('.'))));
         } else {
             unarchiver.setDestDirectory(this.outputDirectory);
         }
         unarchiver.extract();
         outputFile.delete();
+    }
+
+    private boolean isFileUnArchiver(final UnArchiver unarchiver) {
+        return unarchiver instanceof  BZip2UnArchiver ||
+                unarchiver instanceof GZipUnArchiver ||
+                unarchiver instanceof SnappyUnArchiver ||
+                unarchiver instanceof XZUnArchiver;
     }
 
 


### PR DESCRIPTION
# 1. No archiver for `gz`:

Given the pom config:

```xml
<plugin>
    <groupId>com.googlecode.maven-download-plugin</groupId>
    <artifactId>download-maven-plugin</artifactId>
    <executions>
        <execution>
            <id>autodeploy-dashboard-xar</id>
            <phase>generate-test-resources</phase>
            <goals>
                <goal>wget</goal>
            </goals>
            <configuration>
                <url>http://data.exist-db.org/spatial/os-mastermap-topography-layer-sample-data.gz</url>
                <readTimeOut>120000</readTimeOut>
                <sha1>ca14a6dafcdec4cbe9bbadcf65fa1e245665c0e5</sha1>
                <checkSignature>true</checkSignature>
                <unpack>true</unpack>
                <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
            </configuration>
        </execution>
    </executions>
</plugin>
```

I would get an error like:
```
ERROR] Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.4.2-SNAPSHOT:wget (autodeploy-dashboard-xar) on project exist-index-spatial: IO Error: No such archiver: 'gz'. -> [Help 1]
```

It seems that the `plexus-archiver` does not recognise the extension `.gz`, instead it expects `.gzip`. I was able to work around this by adding the following to the configuration:

```xml
<outputFileName>15385-SS7886-5i1.gml.gzip</outputFileName>
```

# 2. NPE when calling `unarchiver.extract();`
Previously the download plugin only set `unarchiver.setDestDirectory(this.outputDirectory);` for the unarchiver, however the `GzipUnArchiver` requires that `setDestFile` is set, otherwise an NPE arrises. This PR fixes that issue... it's a bit *hacky*, but It could not see a better way to fix it right now.