### PR TITLE
Make WGet thread safe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-invoker-plugin</artifactId>
-						<version>2.0.0</version>
+						<version>3.2.0</version>
 						<executions>
 							<execution>
 								<phase>integration-test</phase>
@@ -99,11 +99,11 @@
 									<preBuildHookScript>prepare.groovy</preBuildHookScript>
 									<postBuildHookScript>verify</postBuildHookScript>
 									<debug>true</debug>
-									<environmentVariables>
+									<properties>
 										<testing.versionUnderTest>${project.version}</testing.versionUnderTest>
 										<test.jpg.file.name>lolcatsdotcomcm90ebvhwphtzqvf.jpg</test.jpg.file.name>
 										<test.jpg.file.url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</test.jpg.file.url>
-									</environmentVariables>
+									</properties>
 									<scriptVariables>
 										<jpg_file_name>lolcatsdotcomcm90ebvhwphtzqvf.jpg</jpg_file_name>
 									</scriptVariables>

--- a/src/it/GetAndUnpack/pom.xml
+++ b/src/it/GetAndUnpack/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/GetAndUnpack/pom.xml
+++ b/src/it/GetAndUnpack/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
@@ -30,5 +30,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/GetAndUnpack/verify.groovy
+++ b/src/it/GetAndUnpack/verify.groovy
@@ -1,7 +1,5 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/ant-contrib-1.0b2-bin.zip");
-Assert.assertFalse(f.exists());
+File f = new File(basedir, "target/ant-contrib-1.0b2-bin.zip")
+assert !f.exists()
 f = new File(basedir, "target/ant-contrib/README.txt")
-Assert.assertTrue(f.exists());
-Assert.assertNotSame(0, f.length());
+assert f.exists()
+assert f.length() > 0

--- a/src/it/alwaysOverwrite/pom.xml
+++ b/src/it/alwaysOverwrite/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/alwaysOverwrite/pom.xml
+++ b/src/it/alwaysOverwrite/pom.xml
@@ -13,9 +13,9 @@
 		<plugins>
 			<!--  Download the file first time -->
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
                         <id>first-download</id>
@@ -75,9 +75,9 @@
 			</plugin>
 			<!--  Download the file second time -->
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>${testing.versionUnderTest}</version>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
                 <executions>
                     <execution>
                         <id>second-download</id>
@@ -95,5 +95,5 @@
             </plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/alwaysOverwrite/verify.groovy
+++ b/src/it/alwaysOverwrite/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
 /**
  * Scenario:
  * Given plugin configuration:
@@ -13,15 +11,9 @@ import junit.framework.Assert;
  *
  * `jpg_file_name` is injected through scriptVariables
  */
-File target = new File(basedir, "target");
-File zip = new File(target, jpg_file_name);
-Assert.assertTrue(zip.exists());
-File stamp = new File(target, "stamp");
-Assert.assertTrue(
-  "Timestamp file should exist",
-  stamp.exists()
-);
-Assert.assertTrue(
-  "File expected to be modified but it wasn't",
-  stamp.text != String.valueOf(zip.lastModified())
-);
+File target = new File(basedir, "target")
+File zip = new File(target, jpg_file_name)
+assert zip.exists()
+File stamp = new File(target, "stamp")
+assert stamp.exists() : "Timestamp file should exist"
+assert stamp.text != String.valueOf(zip.lastModified()) : "File expected to be modified but it wasn't"

--- a/src/it/basicGet/pom.xml
+++ b/src/it/basicGet/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/basicGet/pom.xml
+++ b/src/it/basicGet/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
@@ -29,5 +29,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/basicGetWithSignature/pom.xml
+++ b/src/it/basicGetWithSignature/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/basicGetWithSignature/pom.xml
+++ b/src/it/basicGetWithSignature/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
@@ -30,5 +30,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/basicGetWithSignature/verify.groovy
+++ b/src/it/basicGetWithSignature/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/basicGetWithSignatureSha1/pom.xml
+++ b/src/it/basicGetWithSignatureSha1/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/basicGetWithSignatureSha1/pom.xml
+++ b/src/it/basicGetWithSignatureSha1/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/src/it/basicGetWithSignatureSha1/verify.groovy
+++ b/src/it/basicGetWithSignatureSha1/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/basicGetWithSignatureSha512/pom.xml
+++ b/src/it/basicGetWithSignatureSha512/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/basicGetWithSignatureSha512/pom.xml
+++ b/src/it/basicGetWithSignatureSha512/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
@@ -30,5 +30,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/basicGetWithSignatureSha512/verify.groovy
+++ b/src/it/basicGetWithSignatureSha512/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/basicGetWrongSignature/pom.xml
+++ b/src/it/basicGetWrongSignature/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/basicGetWrongSignature/pom.xml
+++ b/src/it/basicGetWrongSignature/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>
@@ -30,5 +30,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/src/it/existingGetWithSignature/pom.xml
+++ b/src/it/existingGetWithSignature/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/existingGetWithSignature/pom.xml
+++ b/src/it/existingGetWithSignature/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/src/it/existingGetWithSignature/prepare.groovy
+++ b/src/it/existingGetWithSignature/prepare.groovy
@@ -1,16 +1,14 @@
-import junit.framework.Assert;
-
-File target = new File(basedir, "target/");
+File target = new File(basedir, "target/")
 if (!target.exists()) {
-  target.mkdirs();
-  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+  target.mkdirs()
+  assert target.exists() : "Folder $target.absolutePath must exist"
 }
 
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
 if (f.exists()) {
-  f.delete();
+  f.delete()
 }
-f.createNewFile();
+f.text = "hello"
 
-Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
-Assert.assertNotSame("File need to be empty", 0, f.length());
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/existingGetWithSignature/verify.groovy
+++ b/src/it/existingGetWithSignature/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/existingGetWithSignatureSha1/pom.xml
+++ b/src/it/existingGetWithSignatureSha1/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/existingGetWithSignatureSha1/pom.xml
+++ b/src/it/existingGetWithSignatureSha1/pom.xml
@@ -12,9 +12,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>download-maven-plugin</artifactId>
-				<version>${testing.versionUnderTest}</version>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>

--- a/src/it/existingGetWithSignatureSha1/prepare.groovy
+++ b/src/it/existingGetWithSignatureSha1/prepare.groovy
@@ -1,16 +1,14 @@
-import junit.framework.Assert;
-
-File target = new File(basedir, "target/");
+File target = new File(basedir, "target/")
 if (!target.exists()) {
-  target.mkdirs();
-  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+  target.mkdirs()
+  assert target.exists() : "Folder $target.absolutePath must exist"
 }
 
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
 if (f.exists()) {
-  f.delete();
+  f.delete()
 }
-f.createNewFile();
+f.text = "hello"
 
-Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
-Assert.assertNotSame("File need to be empty", 0, f.length());
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/existingGetWithSignatureSha1/verify.groovy
+++ b/src/it/existingGetWithSignatureSha1/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/existingGetWithSignatureSha512/pom.xml
+++ b/src/it/existingGetWithSignatureSha512/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<!-- Build plugins and extensions -->

--- a/src/it/existingGetWithSignatureSha512/prepare.groovy
+++ b/src/it/existingGetWithSignatureSha512/prepare.groovy
@@ -1,16 +1,14 @@
-import junit.framework.Assert;
-
-File target = new File(basedir, "target/");
+File target = new File(basedir, "target/")
 if (!target.exists()) {
-  target.mkdirs();
-  Assert.assertTrue("Folder " + target.absolutePath + " must exist", target.exists());
+  target.mkdirs()
+  assert target.exists() : "Folder $target.absolutePath must exist"
 }
 
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
 if (f.exists()) {
-  f.delete();
+  f.delete()
 }
-f.createNewFile();
+f.text = "hello"
 
-Assert.assertTrue("File " + f.absolutePath + " must exist", f.exists());
-Assert.assertNotSame("File need to be empty", 0, f.length());
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/existingGetWithSignatureSha512/verify.groovy
+++ b/src/it/existingGetWithSignatureSha512/verify.groovy
@@ -1,5 +1,3 @@
-import junit.framework.Assert;
-
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg");
-Assert.assertTrue("File " + f.absolutePath + " does not exist", f.exists());
-Assert.assertNotSame("File is empty", 0, f.length());
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/it/parallelRunOnlyAtRoot/invoke.properties
+++ b/src/it/parallelRunOnlyAtRoot/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = -T 4 clean package
+invoker.buildResult = success

--- a/src/it/parallelRunOnlyAtRoot/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test</name>
+
+	<modules>
+		<module>sub1</module>
+		<module>sub2</module>
+		<module>sub3</module>
+		<module>sub4</module>
+	</modules>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
+							<outputFileName>test.jpg</outputFileName>
+							<outputDirectory>${maven.multiModuleProjectDirectory}/target</outputDirectory>
+							<skipCache>true</skipCache>
+							<failOnError>false</failOnError>
+							<runOnlyAtRoot>true</runOnlyAtRoot>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/parallelRunOnlyAtRoot/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<modules>

--- a/src/it/parallelRunOnlyAtRoot/sub1/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub1/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub1</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test1</name>
 </project>

--- a/src/it/parallelRunOnlyAtRoot/sub1/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub1/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub1</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test1</name>
+</project>

--- a/src/it/parallelRunOnlyAtRoot/sub2/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub2/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub2</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 2</name>
+</project>

--- a/src/it/parallelRunOnlyAtRoot/sub2/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub2/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub2</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 2</name>
 </project>

--- a/src/it/parallelRunOnlyAtRoot/sub3/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub3/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub3</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 3</name>
+</project>

--- a/src/it/parallelRunOnlyAtRoot/sub3/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub3/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub3</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 3</name>
 </project>

--- a/src/it/parallelRunOnlyAtRoot/sub4/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub4/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub4</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 4</name>
+</project>

--- a/src/it/parallelRunOnlyAtRoot/sub4/pom.xml
+++ b/src/it/parallelRunOnlyAtRoot/sub4/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub4</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 4</name>
 </project>

--- a/src/it/parallelRunOnlyAtRoot/verify.groovy
+++ b/src/it/parallelRunOnlyAtRoot/verify.groovy
@@ -1,0 +1,13 @@
+File f = new File(basedir, "target/test.jpg")
+
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"
+
+def buildLogText = new File(basedir, 'build.log').text
+def matcher = buildLogText =~/\Qmaven-download-plugin:wget skipped (not project root)\E/
+
+assert matcher.find() : "Project 1 skip"
+assert matcher.find() : "Project 2 skip"
+assert matcher.find() : "Project 3 skip"
+assert matcher.find() : "Project 4 skip"
+assert !matcher.find()  : "No more skipps"

--- a/src/it/parallelToSameFile/invoke.properties
+++ b/src/it/parallelToSameFile/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = -T 4 clean package
+invoker.buildResult = success

--- a/src/it/parallelToSameFile/pom.xml
+++ b/src/it/parallelToSameFile/pom.xml
@@ -8,6 +8,13 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Test</name>
 
+	<modules>
+		<module>sub1</module>
+		<module>sub2</module>
+		<module>sub3</module>
+		<module>sub4</module>
+	</modules>
+
 	<!-- Build plugins and extensions -->
 	<build>
 		<plugins>
@@ -23,8 +30,10 @@
 						</goals>
 						<configuration>
 							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
-							<sha512>b3fc94ecd8cda8acb15198e9b23da84e9de82274643819d8c19858d58132cf25cbd2da46e772a4b5ccac08d062069d234010d7c0e9d9728399ab4870948c2c95</sha512>
-							<checkSignature>true</checkSignature>
+							<outputFileName>test.jpg</outputFileName>
+							<outputDirectory>${maven.multiModuleProjectDirectory}/target</outputDirectory>
+							<skipCache>true</skipCache>
+							<failOnError>false</failOnError>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/parallelToSameFile/pom.xml
+++ b/src/it/parallelToSameFile/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>testBasic</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test</name>
 
 	<modules>

--- a/src/it/parallelToSameFile/sub1/pom.xml
+++ b/src/it/parallelToSameFile/sub1/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub1</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test1</name>
 </project>

--- a/src/it/parallelToSameFile/sub1/pom.xml
+++ b/src/it/parallelToSameFile/sub1/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub1</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test1</name>
+</project>

--- a/src/it/parallelToSameFile/sub2/pom.xml
+++ b/src/it/parallelToSameFile/sub2/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub2</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 2</name>
+</project>

--- a/src/it/parallelToSameFile/sub2/pom.xml
+++ b/src/it/parallelToSameFile/sub2/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub2</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 2</name>
 </project>

--- a/src/it/parallelToSameFile/sub3/pom.xml
+++ b/src/it/parallelToSameFile/sub3/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub3</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 3</name>
+</project>

--- a/src/it/parallelToSameFile/sub3/pom.xml
+++ b/src/it/parallelToSameFile/sub3/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub3</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 3</name>
 </project>

--- a/src/it/parallelToSameFile/sub4/pom.xml
+++ b/src/it/parallelToSameFile/sub4/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.googlecode.maven-download-plugin.it</groupId>
+		<artifactId>testBasic</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>sub4</artifactId>
+	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Test 4</name>
+</project>

--- a/src/it/parallelToSameFile/sub4/pom.xml
+++ b/src/it/parallelToSameFile/sub4/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.googlecode.maven-download-plugin.it</groupId>
 		<artifactId>testBasic</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>${testing.versionUnderTest}</version>
 	</parent>
 
 	<!-- Build description -->
 	<groupId>com.googlecode.maven-download-plugin.it</groupId>
 	<artifactId>sub4</artifactId>
 	<packaging>pom</packaging>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${testing.versionUnderTest}</version>
 	<name>Test 4</name>
 </project>

--- a/src/it/parallelToSameFile/verify.groovy
+++ b/src/it/parallelToSameFile/verify.groovy
@@ -1,3 +1,4 @@
-File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+File f = new File(basedir, "target/test.jpg")
+
 assert f.exists() : "File $f.absolutePath does not exist"
 assert f.length() > 0 : "File is empty"

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -19,6 +19,7 @@ import java.net.ProxySelector;
 import java.net.URI;
 import java.nio.file.Files;
 import java.security.MessageDigest;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -82,8 +83,8 @@ public class WGet extends AbstractMojo {
 
     private static final PoolingHttpClientConnectionManager CONN_POOL;
 
-    private static ConcurrentHashMap<String, DownloadCache> DOWNLOAD_CACHES = new ConcurrentHashMap<>();
-    private static ConcurrentHashMap<String, Lock> FILE_LOCKS = new ConcurrentHashMap<>();
+    private static final Map<String, DownloadCache> DOWNLOAD_CACHES = new ConcurrentHashMap<>();
+    private static final Map<String, Lock> FILE_LOCKS = new ConcurrentHashMap<>();
 
     static {
         CONN_POOL = new PoolingHttpClientConnectionManager(
@@ -314,7 +315,7 @@ public class WGet extends AbstractMojo {
         try {
             lockAcquired = fileLock.tryLock(maxLockWaitTime, TimeUnit.MICROSECONDS);
             if (!lockAcquired) {
-                    String message = "Could not acquire lock for File: " + outputFile + " in " + maxLockWaitTime + "ms";
+                    String message = String.format("Could not acquire lock for File: %s in %dms", outputFile, maxLockWaitTime);
                 if (failOnError) {
                     throw new MojoExecutionException(message);
                 } else {
@@ -418,7 +419,7 @@ public class WGet extends AbstractMojo {
             }
         } catch (Exception ex) {
             throw new MojoExecutionException("IO Error", ex);
-        }finally {
+        } finally {
             if (lockAcquired) {
                 fileLock.unlock();
             }
@@ -450,8 +451,8 @@ public class WGet extends AbstractMojo {
         final RequestConfig requestConfig;
         if (readTimeOut > 0) {
             getLog().info(
-                    "Read Timeout is set to " + readTimeOut + " milliseconds (apprx "
-                            + Math.round(readTimeOut * 1.66667e-5) + " minutes)");
+                    String.format("Read Timeout is set to %d milliseconds (apprx %d minutes)", readTimeOut,
+                            Math.round(readTimeOut * 1.66667e-5)));
             requestConfig = RequestConfig.custom()
                     .setConnectTimeout(readTimeOut)
                     .setSocketTimeout(readTimeOut)

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGet.java
@@ -314,7 +314,13 @@ public class WGet extends AbstractMojo {
         try {
             lockAcquired = fileLock.tryLock(maxLockWaitTime, TimeUnit.MICROSECONDS);
             if (!lockAcquired) {
-                throw new MojoExecutionException("Could not acquire lock for File: " + outputFile+" in " + maxLockWaitTime + "ms");
+                    String message = "Could not acquire lock for File: " + outputFile + " in " + maxLockWaitTime + "ms";
+                if (failOnError) {
+                    throw new MojoExecutionException(message);
+                } else {
+                    getLog().warn(message);
+                    return;
+                }
             }
             boolean haveFile = outputFile.exists();
             if (haveFile) {

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
@@ -15,13 +15,15 @@
  */
 package com.googlecode.download.maven.plugin.internal.cache;
 
-import com.googlecode.download.maven.plugin.internal.SignatureUtils;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
+
 import org.apache.commons.codec.digest.DigestUtils;
+
+import com.googlecode.download.maven.plugin.internal.SignatureUtils;
 
 /**
  * A class representing a download cache
@@ -103,7 +105,7 @@ public class DownloadCache {
         } else if (!basedir.isDirectory()) {
             throw new IllegalArgumentException(
                 String.format(
-                    "Cannot use %s as cache directory: file is already exist",
+                    "Cannot use %s as cache directory: a file already exist there",
                     basedir
                 )
             );

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
@@ -49,19 +49,19 @@ final class FileBackedIndex implements FileIndex {
     }
 
     @Override
-    public void put(final URI uri, final String path) {
+    public synchronized void put(final URI uri, final String path) {
         this.index.put(uri, path);
         this.save();
     }
 
     @Override
-    public boolean contains(final URI uri) {
+    public synchronized boolean contains(final URI uri) {
         this.loadFrom(this.storage);
         return this.index.containsKey(uri);
     }
 
     @Override
-    public String get(final URI uri) {
+    public synchronized String get(final URI uri) {
         if (this.contains(uri)) {
             return this.index.get(uri);
         }
@@ -94,7 +94,7 @@ final class FileBackedIndex implements FileIndex {
      * @param store file where index is persisted.
      */
     @SuppressWarnings("unchecked")
-    private synchronized void loadFrom(final File store) {
+    private void loadFrom(final File store) {
         if (store.length() != 0L) {
             try (
                 final RandomAccessFile file = new RandomAccessFile(store, "r");
@@ -113,7 +113,7 @@ final class FileBackedIndex implements FileIndex {
     /**
      * Saves current im-memory index to file based storage.
      */
-    private synchronized void save() {
+    private void save() {
         try (
             final FileOutputStream file = new FileOutputStream(this.storage);
             final ObjectOutput res = new ObjectOutputStream(file);

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
@@ -94,7 +94,7 @@ final class FileBackedIndex implements FileIndex {
      * @param store file where index is persisted.
      */
     @SuppressWarnings("unchecked")
-    private void loadFrom(final File store) {
+    private synchronized void loadFrom(final File store) {
         if (store.length() != 0L) {
             try (
                 final RandomAccessFile file = new RandomAccessFile(store, "r");
@@ -113,7 +113,7 @@ final class FileBackedIndex implements FileIndex {
     /**
      * Saves current im-memory index to file based storage.
      */
-    private void save() {
+    private synchronized void save() {
         try (
             final FileOutputStream file = new FileOutputStream(this.storage);
             final ObjectOutput res = new ObjectOutputStream(file);


### PR DESCRIPTION
Add option runOnlyAtRoot and make WGet threadSafe by ...

- a shared DownloadCache and synchronizing read/write operations on the
FileBackedIndex
- also use locks for files to prevent concurrent operations on the same
file
- Switch from Java 1.7 to 1.8 to use new ConcurrentHashMap features