### PR TITLE
Fix Cache index retro-compatibility

### DIFF
--- a/src/it/indexRetroCompatibility/invoke.properties
+++ b/src/it/indexRetroCompatibility/invoke.properties
@@ -1,0 +1,3 @@
+invoker.goals.1 = clean package -P version1_3_0
+invoker.goals.2 = package -P currentVersion
+invoker.buildResult = success

--- a/src/it/indexRetroCompatibility/pom.xml
+++ b/src/it/indexRetroCompatibility/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+    <version>${testing.versionUnderTest}</version>
+	<name>Test</name>
+	
+	<properties>
+		<download.cache.directory>${project.build.directory}/cache</download.cache.directory>
+	</properties>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://www.lolcats.com/images/u/08/23/lolcatsdotcomcm90ebvhwphtzqvf.jpg</url>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<profiles>
+		<profile>
+			<id>version1_3_0</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>@project.groupId@</groupId>
+							<artifactId>@project.artifactId@</artifactId>
+							<version>1.3.0</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+		<profile>
+			<id>currentVersion</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>@project.groupId@</groupId>
+							<artifactId>@project.artifactId@</artifactId>
+							<version>@project.version@</version>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/src/it/indexRetroCompatibility/verify.groovy
+++ b/src/it/indexRetroCompatibility/verify.groovy
@@ -1,0 +1,5 @@
+import java.nio.file.Path
+
+File f = new File(basedir, "target/lolcatsdotcomcm90ebvhwphtzqvf.jpg")
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : "File is empty"

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/IncompatibleIndexException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/IncompatibleIndexException.java
@@ -1,0 +1,13 @@
+package com.googlecode.download.maven.plugin.internal.cache;
+
+/**
+ * Thrown when {@link DownloadCache} fails to read an existing index.
+ * <p>
+ * This occurs when upgrading to a new version of the plugin with breaking changes in the index storage strategy
+ * (including Java serialization changes, or even moving to a different serialization mechanism (JSON, XML, etc.).
+ */
+class IncompatibleIndexException extends RuntimeException {
+    IncompatibleIndexException(Exception cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
When reading an index created with an older version of the Plugin,
deserialization errors may rise, due to breaking changes introduced in
newer versions.

Such an index should be droppped (as unreadable) and a new one created
instead, using the new storage strategy.

To test this behavior, a new [Integration test](src/it/indexRetroCompatibility/invoke.properties) have been introduced:
 * download a file with version 1.3.0 (creating an index based on the
 previous storage strategy)
 * download a file with the current version (build should not break)

Should fix #120 .