### PR TITLE
#138 Upgrade maven-core since old one depends on vulnerable com.jcraft:jsch:0.1.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.4</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<id>default-descriptor</id>
@@ -121,7 +121,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>2.0</version>
+			<version>3.6.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/Artifact.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/Artifact.java
@@ -39,7 +39,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
-import org.apache.maven.project.artifact.InvalidDependencyVersionException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 
@@ -275,9 +274,6 @@ public class Artifact extends AbstractMojo {
             getLog().debug("Could not find the dependency", e);
             throw new MojoFailureException("Could not find the dependency : " + e.getMessage());
         } catch (ProjectBuildingException e) {
-            getLog().debug("Error Creating the pom project for artifact : " + artifact, e);
-            throw new MojoFailureException("Error getting transitive dependencies : " + e.getMessage());
-        } catch (InvalidDependencyVersionException e) {
             getLog().debug("Error Creating the pom project for artifact : " + artifact, e);
             throw new MojoFailureException("Error getting transitive dependencies : " + e.getMessage());
         }


### PR DESCRIPTION
fixes #138

This rises the bar for maven to 3.x