### PR TITLE
Fix `alwaysOverwrite` IT on JDK 16 by upgrading to Groovy 3.0.8

### DIFF
--- a/src/it/alwaysOverwrite/pom.xml
+++ b/src/it/alwaysOverwrite/pom.xml
@@ -42,8 +42,8 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>2.4.4</version>
+                        <artifactId>groovy</artifactId>
+                        <version>3.0.8</version>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
The verification step fails under Groovy 2.4.x and 2.5.x, because Groovy tries to access internal Java file APIs which are no longer accessible by default on JDK 16, when using File.exists(). Upgrading from `groovy-all:2.4.4` to `groovy:3.0.8` fixes the issue.

BTW, Maven site generation also has problems on more recent Java versions, but at least I can run all ITs now.