### PR TITLE
Rename `checkSignature` to `alwaysVerifyChecksum`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mvn com.googlecode.maven-download-plugin:download-maven-plugin:1.6.3:artifact -D
 
 ### "WGet" goal
 This is meant to provide the necessary tooling for downloading anything in your Maven build without having to use Ant scripts.
-It provides caching and signature verification.
+It provides caching and checksum verification.
 ```xml
 <plugin>
 	<groupId>com.googlecode.maven-download-plugin</groupId>

--- a/src/it/alwaysOverwrite/verify.groovy
+++ b/src/it/alwaysOverwrite/verify.groovy
@@ -3,7 +3,7 @@
  * Given plugin configuration:
  *  - skipCache = true
  *  - overwrite = true
- *  - no signature specified
+ *  - no checksum specified
  * When Run the plugin to download the zip
  * And Save timestamp into "stamp" file
  * And Run the plugin to download the same zip

--- a/src/it/existingGetWithSignature/pom.xml
+++ b/src/it/existingGetWithSignature/pom.xml
@@ -24,7 +24,7 @@
 						<configuration>
 							<url>${test.img.file.url}</url>
 							<md5>9f8fed0bb43c38c4e2079766680e0161</md5>
-							<checkSignature>true</checkSignature>
+							<alwaysVerifyChecksum>true</alwaysVerifyChecksum>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/existingGetWithSignatureSha1/pom.xml
+++ b/src/it/existingGetWithSignatureSha1/pom.xml
@@ -24,7 +24,7 @@
 						<configuration>
 							<url>${test.img.file.url}</url>
 							<sha1>c02ea6c2bc593c2ffaa20e94ea88c83fe12f232e</sha1>
-							<checkSignature>true</checkSignature>
+							<alwaysVerifyChecksum>true</alwaysVerifyChecksum>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/existingGetWithSignatureSha256/pom.xml
+++ b/src/it/existingGetWithSignatureSha256/pom.xml
@@ -24,7 +24,7 @@
 						<configuration>
 							<url>${test.img.file.url}</url>
 							<sha256>400fc4339b44f4eaa12eaa3539e2aaec747e090bc5bf491f6b37bb592e01384c</sha256>
-							<checkSignature>true</checkSignature>
+							<alwaysVerifyChecksum>true</alwaysVerifyChecksum>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/existingGetWithSignatureSha512/pom.xml
+++ b/src/it/existingGetWithSignatureSha512/pom.xml
@@ -24,7 +24,7 @@
 						<configuration>
 							<url>${test.img.file.url}</url>
 							<sha512>111790db5cbfa8a6db87a487936ffcc1f50edc558b44744f5094ecc4f91011e71d2069da790de86fca31b613131b196d9701019213a965af56e713cf009283a4</sha512>
-							<checkSignature>true</checkSignature>
+							<alwaysVerifyChecksum>true</alwaysVerifyChecksum>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/ChecksumUtils.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/ChecksumUtils.java
@@ -27,16 +27,16 @@ import org.apache.maven.plugin.MojoFailureException;
 /**
  * @author Mickael Istria (Red Hat Inc)
  */
-public class SignatureUtils {
+public class ChecksumUtils {
 
-    public static void verifySignature(File file, String expectedDigest, MessageDigest digest) throws Exception {
-        String actualDigestHex = SignatureUtils.computeSignatureAsString(file, digest);
+    public static void verifyChecksum(File file, String expectedDigest, MessageDigest digest) throws Exception {
+        String actualDigestHex = ChecksumUtils.computeChecksumAsString(file, digest);
         if (!actualDigestHex.equals(expectedDigest)) {
             throw new MojoFailureException("Not same digest as expected: expected <" + expectedDigest + "> was <" + actualDigestHex + ">");
         }
     }
 
-    public static String computeSignatureAsString(File file,
+    public static String computeChecksumAsString(File file,
         MessageDigest digest) throws IOException {
         InputStream fis = new FileInputStream(file);
         byte[] buffer = new byte[1024];
@@ -53,18 +53,18 @@ public class SignatureUtils {
     }
 
     public static String getMD5(File file) throws IOException, NoSuchAlgorithmException {
-        return computeSignatureAsString(file, MessageDigest.getInstance("MD5"));
+        return computeChecksumAsString(file, MessageDigest.getInstance("MD5"));
     }
 
     public static String getSHA1(File file) throws IOException, NoSuchAlgorithmException {
-        return computeSignatureAsString(file, MessageDigest.getInstance("SHA1"));
+        return computeChecksumAsString(file, MessageDigest.getInstance("SHA1"));
     }
 
     public static String getSHA256(File file) throws IOException, NoSuchAlgorithmException {
-        return computeSignatureAsString(file, MessageDigest.getInstance("SHA-256"));
+        return computeChecksumAsString(file, MessageDigest.getInstance("SHA-256"));
     }
 
     public static String getSHA512(File file) throws IOException, NoSuchAlgorithmException {
-        return computeSignatureAsString(file, MessageDigest.getInstance("SHA-512"));
+        return computeChecksumAsString(file, MessageDigest.getInstance("SHA-512"));
     }
 }

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/DownloadCache.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.download.maven.plugin.internal.cache;
 
-import com.googlecode.download.maven.plugin.internal.signature.Signatures;
+import com.googlecode.download.maven.plugin.internal.checksum.Checksums;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
@@ -38,13 +38,13 @@ public final class DownloadCache {
         this.basedir = cacheDirectory;
     }
 
-	private String getEntry(URI uri, final Signatures signatures) {
+	private String getEntry(URI uri, final Checksums checksums) {
 		final String res = this.index.get(uri);
 		if (res == null) {
 			return null;
 		}
 		final File resFile = new File(this.basedir, res);
-		if (resFile.isFile() && signatures.isValid(resFile)) {
+		if (resFile.isFile() && checksums.isValid(resFile)) {
 			return res;
 		} else {
 			return null;
@@ -53,17 +53,17 @@ public final class DownloadCache {
 
 	/**
 	 * Get a File in the download cache. If no cache for this URL, or
-	 * if expected signatures don't match cached ones, returns null.
+	 * if expected checksums don't match cached ones, returns null.
 	 * available in cache,
 	 * @param uri URL of the file
-	 * @param signatures Supplied signatures.
+	 * @param checksums Supplied checksums.
 	 * @return A File when cache is found, null if no available cache
 	 */
-    public File getArtifact(URI uri, final Signatures signatures) {
+    public File getArtifact(URI uri, final Checksums checksums) {
 		final String res;
 		try {
 			this.index.getLock().lock();
-			res = this.getEntry(uri, signatures);
+			res = this.getEntry(uri, checksums);
 		} finally {
 			this.index.getLock().unlock();
 		}
@@ -73,10 +73,10 @@ public final class DownloadCache {
 		return null;
 	}
 
-    public void install(URI uri, File outputFile, final Signatures signatures) throws Exception {
+    public void install(URI uri, File outputFile, final Checksums checksums) throws Exception {
 		try {
 			this.index.getLock().lock();
-			final String entry = this.getEntry(uri, signatures);
+			final String entry = this.getEntry(uri, checksums);
 			if (entry != null) {
 				return; // entry already here
 			}

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/checksum/Checksum.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/checksum/Checksum.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.googlecode.download.maven.plugin.internal.signature;
+package com.googlecode.download.maven.plugin.internal.checksum;
 
 /**
- * Supported signature types with corresponding digest algos.
+ * Supported checksum types with corresponding digest algos.
  * @author Paul Polishchuk
  */
-enum Signature {
+enum Checksum {
     MD5("MD5"),
     SHA1("SHA1"),
     SHA256("SHA-256"),
@@ -27,7 +27,7 @@ enum Signature {
 
     private final String algo;
 
-    Signature(final String algo) {
+    Checksum(final String algo) {
         this.algo = algo;
     }
 

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/checksum/Checksums.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/checksum/Checksums.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.googlecode.download.maven.plugin.internal.signature;
+package com.googlecode.download.maven.plugin.internal.checksum;
 
-import com.googlecode.download.maven.plugin.internal.SignatureUtils;
+import com.googlecode.download.maven.plugin.internal.ChecksumUtils;
 import java.io.File;
 import java.security.MessageDigest;
 import java.util.EnumMap;
@@ -24,31 +24,31 @@ import javax.annotation.Nullable;
 import org.apache.maven.plugin.logging.Log;
 
 /**
- * Signatures supplied to verify file integrity.
+ * Checksums supplied to verify file integrity.
  * @author Paul Polishchuk
  */
-public final class Signatures {
+public final class Checksums {
 
-    private final Map<Signature, String> supplied;
+    private final Map<Checksum, String> supplied;
 
-    public Signatures(
+    public Checksums(
         @Nullable final String md5, @Nullable final String sha1,
         @Nullable final String sha256, @Nullable final String sha512,
         Log log
     ) {
-        this.supplied = Signatures.create(md5, sha1, sha256, sha512);
+        this.supplied = Checksums.create(md5, sha1, sha256, sha512);
         if (this.supplied.isEmpty()) {
-            log.debug("No signatures were supplied, skipping file validation");
+            log.debug("No checksums were supplied, skipping file validation");
         } else if (this.supplied.size() > 1) {
-            log.warn("More than one signature is supplied. This may be slow for big files. Consider using a single signature");
+            log.warn("More than one checksum is supplied. This may be slow for big files. Consider using a single checksum.");
         }
     }
 
     /**
-     * Validates the file with supplied signatures.
+     * Validates the file with supplied checksums.
      * @param file File to validate.
-     * @return True if the file matches all supplied signatures
-     *  or if no signatures were supplied.
+     * @return True if the file matches all supplied checksums
+     *  or if no checksums were supplied.
      */
     public boolean isValid(final File file) {
         boolean valid = true;
@@ -61,13 +61,13 @@ public final class Signatures {
     }
 
     /**
-     * Validates the file with supplied signatures.
+     * Validates the file with supplied checksums.
      * @param file File to validate.
-     * @throws Exception If the file didn't match any supplied signature.
+     * @throws Exception If the file didn't match any supplied checksum.
      */
     public void validate(final File file) throws Exception {
-        for (final Map.Entry<Signature, String> entry : this.supplied.entrySet()) {
-            SignatureUtils.verifySignature(
+        for (final Map.Entry<Checksum, String> entry : this.supplied.entrySet()) {
+            ChecksumUtils.verifyChecksum(
                 file, entry.getValue(),
                 MessageDigest.getInstance(entry.getKey().algo())
             );
@@ -75,30 +75,30 @@ public final class Signatures {
     }
 
     /**
-     * Fill the map of signatures.
-     * @param md5 Supplied md5 signature, may be {@literal null}.
-     * @param sha1 Supplied sha1 signature, may be {@literal null}.
-     * @param sha256 Supplied sha256 signature, may be {@literal null}.
-     * @param sha512 Supplied sha512 signature, may be {@literal null}.
-     * @return A map of a signature type to a digest; {@literal null} digests
+     * Fill the map of checksums.
+     * @param md5 Supplied md5 checksum, may be {@literal null}.
+     * @param sha1 Supplied sha1 checksum, may be {@literal null}.
+     * @param sha256 Supplied sha256 checksum, may be {@literal null}.
+     * @param sha512 Supplied sha512 checksum, may be {@literal null}.
+     * @return A map of a checksum type to a digest; {@literal null} digests
      *  are not included.
      */
-    private static Map<Signature, String> create(
+    private static Map<Checksum, String> create(
         @Nullable final String md5, @Nullable final String sha1,
         @Nullable final String sha256, @Nullable final String sha512
     ) {
-        final Map<Signature, String> digests = new EnumMap<>(Signature.class);
+        final Map<Checksum, String> digests = new EnumMap<>(Checksum.class);
         if (md5 != null) {
-            digests.put(Signature.MD5, md5);
+            digests.put(Checksum.MD5, md5);
         }
         if (sha1 != null) {
-            digests.put(Signature.SHA1, sha1);
+            digests.put(Checksum.SHA1, sha1);
         }
         if (sha256 != null) {
-            digests.put(Signature.SHA256, sha256);
+            digests.put(Checksum.SHA256, sha256);
         }
         if (sha512 != null) {
-            digests.put(Signature.SHA512, sha512);
+            digests.put(Checksum.SHA512, sha512);
         }
         return digests;
     }


### PR DESCRIPTION
Fixes #186, see the naming and documentation discussion there.

First, the plan was to just rename the one parameter and keep the one with the old name around as deprecated. while doing so, I noticed lots of
  - class and package names,
  - method names and parameters,
  - javadocs and comments,

referring to digest-based checksums like SHA-1 and MD5 as "signatures" too, so I took care of globally renaming all of those too. That should make it easier to work with the code base in the future.

BTW, along the way I encountered the problem solved by #190, so maybe you want to merge than one first, if you like to run ITs on JDK 16 against this PR. Otherwise, the merge order does not matter.