### PR TITLE
bump http client version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ env:
 jdk:
   - openjdk8
 script:
-  - mvn clean install --batch-mode --errors
-  - mvn verify -Pits --batch-mode --errors
+  - mvn clean install --batch-mode --errors -Dinvoker.streamLogsOnFailures=true
+  - mvn verify -Pits --batch-mode --errors -Dinvoker.streamLogsOnFailures=true

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-invoker-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>3.2.2</version>
 						<executions>
 							<execution>
 								<phase>integration-test</phase>
@@ -148,7 +148,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.6</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
instead of https://github.com/maven-download-plugin/maven-download-plugin/pull/187

Had to bump invoker plugin version to make `streamLogsOnFailures` param work so we could see why travis build fails