### PR TITLE
Bumping dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,30 +119,30 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>3.8.2</version>
+			<artifactId>maven-compat</artifactId>
+			<version>3.8.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>2.0</version>
+			<version>3.8.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.4</version>
+			<version>3.6.4</version>
 			<scope>provided</scope><!-- annotations are needed only to build the plugin -->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>2.0</version>
+			<version>3.8.6</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-project</artifactId>
-			<version>2.0</version>
+			<version>2.2.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -153,17 +153,17 @@
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-archiver</artifactId>
-			<version>4.2.5</version>
+			<version>4.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
-			<version>3.1.0</version>
+			<version>3.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-provider-api</artifactId>
-			<version>2.12</version>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.sonatype.plexus</groupId>
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -193,7 +193,7 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
-			<version>1.2</version>
+			<version>3.3.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -205,7 +205,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>4.7.0</version>
+			<version>4.8.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Ran `display-dependency-updates '-Dmaven.version.ignore=.*-(alpha|beta).*'`

```
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   junit:junit ......................................... 4.13.1 -> 4.13.2
[INFO]   org.apache.maven:maven-artifact ......................... 2.0 -> 3.8.6
[INFO]   org.apache.maven:maven-core ........................... 3.8.2 -> 3.8.6
[INFO]   org.apache.maven:maven-plugin-api ....................... 2.0 -> 3.8.6
[INFO]   org.apache.maven:maven-project .......................... 2.0 -> 2.2.1
[INFO]   org.apache.maven.plugin-testing:maven-plugin-testing-harness ...
[INFO]                                                             1.2 -> 3.3.0
[INFO]   org.apache.maven.plugin-tools:maven-plugin-annotations ...
[INFO]                                                             3.4 -> 3.6.4
[INFO]   org.apache.maven.wagon:wagon-provider-api .............. 2.12 -> 3.5.2
[INFO]   org.codehaus.plexus:plexus-archiver ................... 4.2.5 -> 4.5.0
[INFO]   org.codehaus.plexus:plexus-utils ...................... 3.1.0 -> 3.4.2
[INFO]   org.mockito:mockito-inline ............................ 4.7.0 -> 4.8.0
[INFO]   org.slf4j:slf4j-simple ............................... 1.7.36 -> 2.0.2
```

slf4j v2.0.0 is currently not compatible with maven-compat, so it should stay at 1.7.