### PR TITLE
#224, #226: Replacing Maven 2 APIs with Maven 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ It provides caching and checksum verification.
 </plugin>
 ```
 
+## Requirements
+
+Starting from version 1.6.9, the plugin requires Maven version 3 or above.
+
 ## Known issues and workarounds
 
 ### IO Error: No such archiver

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,29 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>mrm-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>start</goal>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<repositories>
+								<mockRepo>
+									<source>src/it-repo</source>
+								</mockRepo>
+								<localRepo>
+									<source>${project.build.directory}/local-repo</source>
+								</localRepo>
+								<proxyRepo />
+							</repositories>
+						</configuration>
+					</plugin>
+					<plugin>
 						<artifactId>maven-invoker-plugin</artifactId>
 						<version>3.2.2</version>
 						<executions>
@@ -109,6 +132,9 @@
 										<img_file_name>687474703a2f2f696d672e71756c6963652e636f6d2f6c6f676f2d6269672e706e67</img_file_name>
 									</scriptVariables>
 									<settingsFile>src/it/settings.xml</settingsFile>
+									<filterProperties>
+										<mrm.repository.url>${mrm.repository.url}</mrm.repository.url>
+									</filterProperties>
 								</configuration>
 							</execution>
 						</executions>

--- a/src/it-repo/dummy-api-1.0.jar
+++ b/src/it-repo/dummy-api-1.0.jar
@@ -1,0 +1,1 @@
+dummy-api

--- a/src/it-repo/dummy-api-1.0.pom
+++ b/src/it-repo/dummy-api-1.0.pom
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>dummy-api</artifactId>
+  <version>1.0</version>
+
+</project>

--- a/src/it-repo/dummy-dependency-1.0.jar
+++ b/src/it-repo/dummy-dependency-1.0.jar
@@ -1,0 +1,1 @@
+dummy-dependency

--- a/src/it-repo/dummy-dependency-1.0.pom
+++ b/src/it-repo/dummy-dependency-1.0.pom
@@ -4,15 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>localhost</groupId>
-  <artifactId>dummy-api</artifactId>
+  <artifactId>dummy-dependency</artifactId>
   <version>1.0</version>
-
-  <dependencies>
-    <dependency>
-      <groupId>localhost</groupId>
-      <artifactId>dummy-dependency</artifactId>
-      <version>1.0</version>
-    </dependency>
-  </dependencies>
 
 </project>

--- a/src/it-repo/dummy-impl-1.0.jar
+++ b/src/it-repo/dummy-impl-1.0.jar
@@ -1,0 +1,1 @@
+dummy-impl

--- a/src/it-repo/dummy-impl-1.0.pom
+++ b/src/it-repo/dummy-impl-1.0.pom
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>dummy-impl</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>dummy-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/basicArtifact/invoke.properties
+++ b/src/it/basicArtifact/invoke.properties
@@ -1,2 +1,2 @@
 invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:artifact
-invoker.mavenOpts = -DgroupId=org.codehaus.mojo -DartifactId=mojo-parent -Dversion=70 -Dtype=pom -DoutputDirectory=target -DoutputFileName=pom.xml
+invoker.mavenOpts = -DgroupId=localhost -DartifactId=dummy-api -Dversion=1.0 -Dtype=pom -DoutputDirectory=target -DoutputFileName=target-pom.xml

--- a/src/it/basicArtifact/invoke.properties
+++ b/src/it/basicArtifact/invoke.properties
@@ -1,0 +1,2 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:artifact
+invoker.mavenOpts = -DgroupId=org.codehaus.mojo -DartifactId=mojo-parent -Dversion=70 -Dtype=pom -DoutputDirectory=target -DoutputFileName=pom.xml

--- a/src/it/basicArtifact/pom.xml
+++ b/src/it/basicArtifact/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>basicArtifact</artifactId>
+	<packaging>pom</packaging>
+    <version>${testing.versionUnderTest}</version>
+	<name>Test</name>
+
+</project>

--- a/src/it/basicArtifact/verify.groovy
+++ b/src/it/basicArtifact/verify.groovy
@@ -1,3 +1,3 @@
-def f = new File(basedir, 'target/pom.xml')
+def f = new File(basedir, 'target/target-pom.xml')
 assert f.exists() : "File $f.absolutePath does not exist"
-assert f.length() > 0 : 'File is empty'
+assert f.text.contains('<artifactId>dummy-api</artifactId>')

--- a/src/it/basicArtifact/verify.groovy
+++ b/src/it/basicArtifact/verify.groovy
@@ -1,0 +1,3 @@
+def f = new File(basedir, 'target/pom.xml')
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : 'File is empty'

--- a/src/it/basicArtifactTransitive/invoke.properties
+++ b/src/it/basicArtifactTransitive/invoke.properties
@@ -1,3 +1,6 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:artifact
-invoker.mavenOpts = -DgroupId=javax.annotation -DartifactId=javax.annotation-api -Dversion=1.3.2 -DdependencyDepth=1
-invoker.buildResult = success
+invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:artifact
+invoker.mavenOpts.1 = -DgroupId=localhost -DartifactId=dummy-impl -Dversion=1.0 -DdependencyDepth=1
+
+# for testing with "real-world" artifacts:
+# invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:artifact
+# invoker.mavenOpts.2 = -DgroupId=org.codehaus.plexus -DartifactId=plexus-utils -Dversion=3.5.0 -DdependencyDepth=1

--- a/src/it/basicArtifactTransitive/invoke.properties
+++ b/src/it/basicArtifactTransitive/invoke.properties
@@ -1,0 +1,3 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:artifact
+invoker.mavenOpts = -DgroupId=javax.annotation -DartifactId=javax.annotation-api -Dversion=1.3.2 -DdependencyDepth=1
+invoker.buildResult = success

--- a/src/it/basicArtifactTransitive/pom.xml
+++ b/src/it/basicArtifactTransitive/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>basicArtifactTransitive</artifactId>
+	<packaging>pom</packaging>
+    <version>${testing.versionUnderTest}</version>
+	<name>Test</name>
+
+</project>

--- a/src/it/basicArtifactTransitive/verify.groovy
+++ b/src/it/basicArtifactTransitive/verify.groovy
@@ -6,3 +6,6 @@ def verifyFile(fileName) {
 
 verifyFile('dummy-api-1.0.jar')
 verifyFile('dummy-impl-1.0.jar')
+
+// only up to 1-level dependencies should be downloaded
+assert !( new File(basedir, 'target/dummy-dependency-1.0.jar').exists() )

--- a/src/it/basicArtifactTransitive/verify.groovy
+++ b/src/it/basicArtifactTransitive/verify.groovy
@@ -1,0 +1,3 @@
+def f = new File(basedir, 'target/javax.annotation-api-1.3.2.jar')
+assert f.exists() : "File $f.absolutePath does not exist"
+assert f.length() > 0 : 'File is empty'

--- a/src/it/basicArtifactTransitive/verify.groovy
+++ b/src/it/basicArtifactTransitive/verify.groovy
@@ -1,3 +1,8 @@
-def f = new File(basedir, 'target/javax.annotation-api-1.3.2.jar')
-assert f.exists() : "File $f.absolutePath does not exist"
-assert f.length() > 0 : 'File is empty'
+def verifyFile(fileName) {
+    def file = new File(basedir, "target/${fileName}")
+    assert file.exists() : "File $file.absolutePath does not exist"
+    assert file.size() != 0
+}
+
+verifyFile('dummy-api-1.0.jar')
+verifyFile('dummy-impl-1.0.jar')

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -22,6 +22,14 @@ under the License.
 	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
 	xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+	<mirrors>
+		<mirror>
+			<id>mrm-maven-plugin</id>
+			<name>Mock Repository Manager</name>
+			<url>@mrm.repository.url@</url>
+			<mirrorOf>*</mirrorOf>
+		</mirror>
+	</mirrors>
 	<servers>
 		<server>
 			<id>y</id>
@@ -37,24 +45,32 @@ under the License.
 			<repositories>
 				<repository>
 					<id>local.central</id>
-					<url>@localRepositoryUrl@</url>
+					<url>@mrm.repository.url@</url>
 					<releases>
 						<enabled>true</enabled>
+						<checksumPolicy>ignore</checksumPolicy>
+						<updatePolicy>never</updatePolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<checksumPolicy>ignore</checksumPolicy>
+						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>
 					<id>local.central</id>
-					<url>@localRepositoryUrl@</url>
+					<url>@mrm.repository.url@</url>
 					<releases>
 						<enabled>true</enabled>
+						<checksumPolicy>ignore</checksumPolicy>
+						<updatePolicy>never</updatePolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<checksumPolicy>ignore</checksumPolicy>
+						<updatePolicy>always</updatePolicy>
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
@@ -259,7 +259,7 @@ public class HttpFileRequester {
         private String decrypt(String str, String server) {
             try  {
                 return this.secDispatcher.decrypt(str);
-            } catch(final SecDispatcherException e) {
+            } catch (final SecDispatcherException e) {
                 this.log.warn(String.format("Failed to decrypt password/passphrase for server %s,"
                         + " using auth token as is", server), e);
                 return str;
@@ -271,7 +271,6 @@ public class HttpFileRequester {
     /**
      * Downloads the resource with the given URI to the specified local file system location.
      *
-     * @param uri the target URI
      * @param outputFile the output file
      * @param headers list of headers
      */

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -469,11 +469,11 @@ public class WGetMojo extends AbstractMojo {
 
         // set proxy if present
         Optional.ofNullable(this.session.getRepositorySession().getProxySelector())
-                .flatMap(selector -> Optional.ofNullable(selector.getProxy(repository)))
+                .map(selector -> selector.getProxy(repository))
                 .ifPresent(proxy -> addProxy(fileRequesterBuilder, repository, proxy));
 
         Optional.ofNullable(this.session.getRepositorySession().getAuthenticationSelector())
-                .flatMap(selector -> Optional.ofNullable(selector.getAuthentication(repository)))
+                .map(selector -> selector.getAuthentication(repository))
                 .ifPresent(auth -> addAuthentication(fileRequesterBuilder, repository, auth));
 
         if (!this.skipCache) {

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -37,10 +37,8 @@ import org.eclipse.aether.repository.AuthenticationContext;
 import org.eclipse.aether.repository.Proxy;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.sonatype.plexus.build.incremental.BuildContext;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -241,14 +239,6 @@ public class WGetMojo extends AbstractMojo {
 
     @Inject
     private BuildContext buildContext;
-
-
-    /**
-     * (Injected) Maven Security Dispatcher
-     */
-    @Inject
-    @Named( "mng-4384" )
-    private SecDispatcher secDispatcher;
 
     /**
      * Runs the plugin only if the current project is the execution root.
@@ -493,7 +483,6 @@ public class WGetMojo extends AbstractMojo {
                 .withPassword(this.password)
                 .withServerId(this.serverId)
                 .withPreemptiveAuth(this.preemptiveAuth)
-                .withSecDispatcher(this.secDispatcher)
                 .withMavenSession(this.session)
                 .withRedirectsEnabled(this.followRedirects)
                 .withLog(this.getLog())
@@ -535,7 +524,7 @@ public class WGetMojo extends AbstractMojo {
             final String ntlmHost = authCtx.get(AuthenticationContext.NTLM_WORKSTATION);
 
             getLog().debug("providing custom authentication");
-            getLog().debug("username: " + this.username + " and password: ***");
+            getLog().debug("username: " + username + " and password: ***");
 
             fileRequesterBuilder.withUsername(username);
             fileRequesterBuilder.withPassword(password);

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -448,16 +448,24 @@ public class WGetMojo extends AbstractMojo {
                 unarchiver instanceof XZUnArchiver;
     }
 
+    private static RemoteRepository createRemoteRepository(String serverId, URI uri)
+    {
+        return new RemoteRepository.Builder(isBlank(serverId)
+                    ? null
+                    : serverId,
+                isBlank(serverId)
+                    ? uri.getScheme()
+                    : null,
+                isBlank(serverId)
+                    ? uri.getHost()
+                    : null)
+                .build();
+    }
 
     private void doGet(final File outputFile) throws IOException, MojoExecutionException {
         final HttpFileRequester.Builder fileRequesterBuilder = new HttpFileRequester.Builder();
 
-        final RemoteRepository repository = new RemoteRepository.Builder(isBlank(this.serverId)
-            ? null
-            : this.serverId,
-                isBlank(this.serverId) ? this.uri.getScheme() : null,
-                isBlank(this.serverId) ? this.uri.getHost() : null)
-                .build();
+        final RemoteRepository repository = createRemoteRepository(this.serverId, this.uri);
 
         // set proxy if present
         Optional.ofNullable(this.session.getRepositorySession().getProxySelector())

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/HttpFileRequesterTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/HttpFileRequesterTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
 import java.io.File;
 import java.net.URI;
@@ -57,7 +56,6 @@ public class HttpFileRequesterTest {
                 .withConnectTimeout(3000)
                 .withSocketTimeout(3000)
                 .withUri(new URI(this.wireMock.baseUrl()))
-                .withSecDispatcher(mock(SecDispatcher.class))
                 .withRedirectsEnabled(false)
                 .withPreemptiveAuth(false)
                 .withCacheDir(null)

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.MockedStatic;
 import org.sonatype.plexus.build.incremental.BuildContext;
-import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
 import java.io.File;
 import java.io.IOException;
@@ -91,7 +90,6 @@ public class WGetTest {
         setVariableValueToObject(mojo, "retries", 1);
         setVariableValueToObject(mojo, "buildContext", buildContext);
         setVariableValueToObject(mojo, "overwrite", true);
-        setVariableValueToObject(mojo, "secDispatcher", mock(SecDispatcher.class));
         try {
             setVariableValueToObject(mojo, "uri", new URI(
                     "http://test"));

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
@@ -8,13 +8,12 @@ import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestExecutor;
-import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,6 +26,7 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -47,7 +47,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit tests for {@link WGet}
+ * Unit tests for {@link WGetMojo}
  *
  * @author Andrzej Jarmoniuk
  */
@@ -70,28 +70,28 @@ public class WGetTest {
         temporaryFolder.delete();
     }
 
-    private <T, M extends Mojo> void setVariableValueToObject(M mojo, String variable, T value) {
+    private <T> void setVariableValueToObject(Object object, String variable, T value) {
         try {
-            org.apache.maven.plugin.testing.ArtifactStubFactory.setVariableValueToObject(mojo, variable, value);
+            Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses(variable, object.getClass());
+            field.setAccessible(true);
+            field.set(object, value);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private WGet createMojo(Consumer<WGet> initializer) {
-        WGet mojo = new WGet();
+    private WGetMojo createMojo(Consumer<WGetMojo> initializer) {
+        WGetMojo mojo = new WGetMojo();
         BuildContext buildContext = mock(BuildContext.class);
         doNothing().when(buildContext).refresh(any(File.class));
 
         setVariableValueToObject(mojo, "outputFileName", OUTPUT_FILE_NAME);
         setVariableValueToObject(mojo, "outputDirectory", outputDirectory.toFile());
         setVariableValueToObject(mojo, "cacheDirectory", cacheDirectory.toFile());
-        setVariableValueToObject(mojo, "wagonManager", mock(WagonManager.class));
         setVariableValueToObject(mojo, "retries", 1);
-        setVariableValueToObject(mojo, "settings", new Settings());
         setVariableValueToObject(mojo, "buildContext", buildContext);
         setVariableValueToObject(mojo, "overwrite", true);
-        setVariableValueToObject(mojo, "securityDispatcher", mock(SecDispatcher.class));
+        setVariableValueToObject(mojo, "secDispatcher", mock(SecDispatcher.class));
         try {
             setVariableValueToObject(mojo, "uri", new URI(
                     "http://test"));
@@ -102,6 +102,9 @@ public class WGetTest {
             @SuppressWarnings("deprecation")
             MavenSessionStub() {
                 super(null, mock(MavenExecutionRequest.class), null, new LinkedList<>());
+                final DefaultRepositorySystemSession repositorySystemSession = new DefaultRepositorySystemSession();
+                repositorySystemSession.setOffline(true);
+                setVariableValueToObject(this, "repositorySession", repositorySystemSession);
             }
         }
         setVariableValueToObject(mojo, "session", new MavenSessionStub());
@@ -169,7 +172,7 @@ public class WGetTest {
     }
 
     /**
-     * Verifies that the cache directory should remain empty if the {@linkplain WGet#execute()} execution
+     * Verifies that the cache directory should remain empty if the {@linkplain WGetMojo#execute()} execution
      * ended abruptly. Does so by keeping {@code wagonManager} {@code null}. As it's being dereferenced,
      * an NPE is raised.
      *
@@ -178,9 +181,14 @@ public class WGetTest {
     @Test
     public void testCacheNotWrittenToIfFailed() throws Exception {
         try {
-            createMojo(mojo -> setVariableValueToObject(mojo, "wagonManager", null)).execute();
+            WGetMojo mojo = createMojo(ignored -> {
+                return;
+            });
+            // inject null value so that we get a NullPointerException thrown
+            setVariableValueToObject(mojo, "session", null);
+            mojo.execute();
             fail();
-        } catch (MojoExecutionException e) {
+        } catch (NullPointerException e) {
             // expected, but can be ignored
         } finally {
             assertThat("Cache directory should remain empty if quit abruptly", cacheDirectory.toFile().list(),
@@ -232,11 +240,11 @@ public class WGetTest {
     public void testCacheRetainingValuesFromTwoConcurrentCalls() throws Exception {
         final URI firstMojoUri = URI.create("http://test/foo");
         final URI secondMojoUri = URI.create("http://test/bar");
-        WGet firstMojo = createMojo(mojo -> {
+        WGetMojo firstMojo = createMojo(mojo -> {
             setVariableValueToObject(mojo, "uri", firstMojoUri);
             setVariableValueToObject(mojo, "outputFileName", OUTPUT_FILE_NAME);
         });
-        WGet secondMojo = createMojo(mojo -> {
+        WGetMojo secondMojo = createMojo(mojo -> {
             setVariableValueToObject(mojo, "uri", secondMojoUri);
             setVariableValueToObject(mojo, "outputFileName", "second-output-file");
         });


### PR DESCRIPTION
Replacing Maven 2 APIs like ArtifactMetadataSource, ArtifactResolver, WagonManager, etc., with current, non-deprecated alternatives. Also, moving to JSR330 to be compliant with latest Maven standards and recommendations.

`Mojo`, `Artifact`: Class name changed to be in line with maven plugin naming conventions.