### PR TITLE
Resolves #238: Handling download failures

### DIFF
--- a/src/it/GetAndUnpack/pom.xml
+++ b/src/it/GetAndUnpack/pom.xml
@@ -22,6 +22,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
+							<!-- downloading a locally hosted jar archive, containing a "Hello, world!" text -->
 							<url>@mrm.repository.url@/localhost/hello/1.0/hello-1.0.jar</url>
 							<unpack>true</unpack>
 						</configuration>

--- a/src/it/GetAndUnpackWithFileMapper/pom.xml
+++ b/src/it/GetAndUnpackWithFileMapper/pom.xml
@@ -22,6 +22,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
+                            <!-- downloading a locally hosted jar archive, containing a "Hello, world!" text -->
                             <url>@mrm.repository.url@/localhost/hello/1.0/hello-1.0.jar</url>
                             <unpack>true</unpack>
                             <fileMappers>

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -6,7 +6,7 @@ package com.googlecode.download.maven.plugin.internal;
  */
 public class DownloadFailureException extends Exception {
 
-    private int statusCode;
+    private final int statusCode;
 
     private String statusLine;
 

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -1,0 +1,41 @@
+package com.googlecode.download.maven.plugin.internal;
+
+/**
+ * Represents a download failure exception, thrown when the requested resource returns
+ * a non-20x HTTP code.
+ */
+public class DownloadFailureException extends Exception {
+
+    private int statusCode;
+
+    private String statusLine;
+
+    /**
+     * @return the HTTP status code.
+     */
+    public int getHttpCode() {
+        return statusCode;
+    }
+
+    /**
+     * @return the HTTP status line.
+     */
+    public String getStatusLine() {
+        return statusLine;
+    }
+
+    /**
+     * Creates a new instance.
+     * @param statusCode HTTP code
+     * @param statusLine status line
+     */
+    public DownloadFailureException(int statusCode, String statusLine) {
+        this.statusCode = statusCode;
+        this.statusLine = statusLine;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Download failed with code " + statusCode + ": " + statusLine;
+    }
+}

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -36,6 +36,6 @@ public class DownloadFailureException extends Exception {
 
     @Override
     public String getMessage() {
-        return "Download failed with code " + statusCode + ": " + statusLine;
+        return "Download failed with code " + getHttpCode() + ": " + getStatusLine();
     }
 }

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -8,7 +8,7 @@ public class DownloadFailureException extends Exception {
 
     private final int statusCode;
 
-    private String statusLine;
+    private final String statusLine;
 
     /**
      * @return the HTTP status code.

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -4,7 +4,7 @@ package com.googlecode.download.maven.plugin.internal;
  * Represents a download failure exception, thrown when the requested resource returns
  * a non-20x HTTP code.
  */
-public class DownloadFailureException extends Exception {
+public final class DownloadFailureException extends Exception {
 
     private final int statusCode;
 

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/DownloadFailureException.java
@@ -4,7 +4,7 @@ package com.googlecode.download.maven.plugin.internal;
  * Represents a download failure exception, thrown when the requested resource returns
  * a non-20x HTTP code.
  */
-public final class DownloadFailureException extends Exception {
+public final class DownloadFailureException extends RuntimeException {
 
     private final int statusCode;
 

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
@@ -305,7 +305,7 @@ public class HttpFileRequester {
      */
     private Object handleResponse( URI uri, File outputFile, HttpCacheContext clientContext, HttpResponse response )
             throws IOException, DownloadFailureException {
-        if (response.getStatusLine().getStatusCode() >= 300) {
+        if (response.getStatusLine().getStatusCode() >= 400) {
             throw new DownloadFailureException(response.getStatusLine().getStatusCode(),
                     response.getStatusLine().getReasonPhrase());
         }

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -474,7 +474,7 @@ public class WGetMojo extends AbstractMojo {
                 .build();
     }
 
-    private void doGet(final File outputFile) throws IOException, MojoExecutionException, DownloadFailureException {
+    private void doGet(final File outputFile) throws IOException, MojoExecutionException {
         final HttpFileRequester.Builder fileRequesterBuilder = new HttpFileRequester.Builder();
 
         final RemoteRepository repository = createRemoteRepository(this.serverId, this.uri);

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetMojoTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetMojoTest.java
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -57,7 +56,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Andrzej Jarmoniuk
  */
-public class WGetTest {
+public class WGetMojoTest {
     @Rule
     public WireMockRule wireMock = new WireMockRule(options().dynamicPort());
     @Rule

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
@@ -626,7 +626,7 @@ public class WGetTest {
     }
 
     /**
-     * Plugin execution should fail if a non-200 code was returned by the resource being downloaded.
+     * Plugin execution should fail if code >= 400 was returned by the resource being downloaded.
      */
     @Test
     public void testBuildShouldFailIfDownloadFails() {

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
@@ -642,6 +642,7 @@ public class WGetTest {
             assertThat(e, is(instanceOf(MojoExecutionException.class)));
             assertThat(e.getCause(), is(instanceOf(DownloadFailureException.class)));
             assertThat(((DownloadFailureException) e.getCause()).getHttpCode(), is(HttpStatus.SC_FORBIDDEN));
+            verify(1, getRequestedFor(anyUrl()));
         }
     }
 
@@ -679,6 +680,7 @@ public class WGetTest {
                 setVariableValueToObject(m, "skipCache", true);
                 setVariableValueToObject(m, "failOnError", false);
             }).execute();
+            verify(1, getRequestedFor(anyUrl()));
         } catch (MojoExecutionException e) {
             if (e.getCause() instanceof DownloadFailureException) {
                 fail("Plugin should ignore a download failure");

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/WGetTest.java
@@ -627,6 +627,7 @@ public class WGetTest {
 
     /**
      * Plugin execution should fail if code >= 400 was returned by the resource being downloaded.
+     * It should not repeat the query.
      */
     @Test
     public void testBuildShouldFailIfDownloadFails() {
@@ -649,6 +650,7 @@ public class WGetTest {
     /**
      * Plugin execution should fail only after all retries have been exhausted
      * if a 500+ code was returned by the resource being downloaded.
+     * It should repeat the query exactly 3 times.
      */
     @Test
     public void testRetriedAfterDownloadFailsWithCode500() {
@@ -668,7 +670,7 @@ public class WGetTest {
     }
 
     /**
-     * Plugin should ignore a download failure if instructed to do so.
+     * Plugin should ignore a download failure if instructed to do so. It should not repeat the query.
      */
     @Test
     public void testIgnoreDownloadFailure()


### PR DESCRIPTION
This PR causes the plugin to fail (unless `failOnError` is `false`) upon a failed download attempt. With errors which can be transient, like 500, it's honoring the `retries` setting.

@longtimeago please check