### PR TITLE
Fixing the broken release 1.7.0 #246

### DIFF
--- a/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/HttpFileRequester.java
@@ -288,6 +288,11 @@ public class HttpFileRequester {
             throw new DownloadFailureException(response.getStatusLine().getStatusCode(),
                     response.getStatusLine().getReasonPhrase());
         }
+        if (response.getStatusLine().getStatusCode() >= 301 && response.getStatusLine().getStatusCode() <= 303) {
+            throw new DownloadFailureException(response.getStatusLine().getStatusCode(),
+                    response.getStatusLine().getReasonPhrase()
+                            + ". Not downloading the resource because followRedirects is false.");
+        }
         final HttpEntity entity = response.getEntity();
         if (entity != null) {
             switch ( clientContext.getCacheResponseStatus()) {
@@ -336,6 +341,8 @@ public class HttpFileRequester {
             CacheConfig config = CacheConfig.custom()
                     .setHeuristicDefaultLifetime(HEURISTIC_DEFAULT_LIFETIME)
                     .setHeuristicCachingEnabled(true)
+                    .setMaxObjectSize(Long.MAX_VALUE)
+                    .setMaxCacheEntries(Integer.MAX_VALUE)
                     .build();
             httpClientBuilder
                     .setCacheDir(this.cacheDir)

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -216,10 +216,12 @@ public class WGetMojo extends AbstractMojo {
     private boolean checkSignature;
 
     /**
-     * Whether to follow redirects (302)
+     * <p>Whether to follow redirects (301 Moved Permanently, 302 Found, 303 See Other).</p>
+     * <p>If this option is disabled and the returned resource returns a redirect, the plugin will report an error
+     * and exit unless {@link #failOnError} is {@code false}.</p>
      */
-    @Parameter(property = "download.plugin.followRedirects", defaultValue = "false")
-    private boolean followRedirects;
+    @Parameter(property = "download.plugin.followRedirects", defaultValue = "true")
+    private boolean followRedirects = true;
 
     /**
      * A list of additional HTTP headers to send with the request
@@ -385,7 +387,7 @@ public class WGetMojo extends AbstractMojo {
                     }
                 }
                 boolean done = false;
-                for (int retriesLeft = this.retries; retriesLeft > 0; --retriesLeft) {
+                for (int retriesLeft = this.retries; !done && retriesLeft > 0; --retriesLeft) {
                     try {
                         this.doGet(outputFile);
                         checksums.validate(outputFile);

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndex.java
@@ -145,15 +145,13 @@ public final class FileBackedIndex implements HttpCacheStorage {
         }
         Path cachedFile = Paths.get(this.index.get(uri));
         if (!Files.exists(baseDir.resolve(cachedFile))) {
-            log.debug("Cached version of " + uri + " is gone; deleting cache entry");
-            this.index.remove(uri);
+            log.warn("Cached version of " + uri + " is gone; deleting cache entry");
             try {
-                this.load(cacheIndexFile);
+                this.index.remove(uri);
                 this.save();
+                return null;
             } catch (IncompatibleIndexException e) {
                 log.warn("Could not load index cache index file, it will be rewritten.");
-            } catch (IOException e) {
-                log.warn("Unable to update cache.");
             }
         }
         return asHttpCacheEntry(cachedFile, baseDir);

--- a/src/test/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndexTest.java
+++ b/src/test/java/com/googlecode/download/maven/plugin/internal/cache/FileBackedIndexTest.java
@@ -1,9 +1,21 @@
 package com.googlecode.download.maven.plugin.internal.cache;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.cache.HttpCacheEntry;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.junit.Test;
+import wiremock.org.eclipse.jetty.http.HttpStatus;
 
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -30,5 +42,35 @@ public class FileBackedIndexTest {
     @Test
     public void testUriWithAdditionalHeaderInfoUri() {
         assertThat(FileBackedIndex.asUri("{Accept-Encoding=gzip%2Cdeflate}https://postman-echo.com:443/get"), is(URI.create("https://postman-echo.com/get")));
+    }
+
+    /**
+     * Cache should check if the file mapped by the index has been deleted by the user and
+     * remove the file from the index reverting to retrieving the remote resource.
+     */
+    @Test
+    public void testIndexedFileNotFound() throws Exception {
+        class ClosablePath implements AutoCloseable {
+            private final Path dir;
+            public ClosablePath(Path dir) {
+                this.dir = dir;
+            }
+
+            @Override
+            public void close() throws Exception {
+                FileUtils.deleteDirectory(dir.toFile());
+            }
+        }
+
+        Path path = Files.createTempDirectory("file-backed-index");
+        try (AutoCloseable ignored = new ClosablePath(path)){
+            FileBackedIndex index = new FileBackedIndex(path, new SystemStreamLog());
+            index.putEntry("foo://file.bin",
+                    new HttpCacheEntry(new Date(), new Date(),
+                            new BasicStatusLine(HttpVersion.HTTP_1_1,
+                                    HttpStatus.OK_200, "OK"), new Header[]{},
+                            new FileIndexResource(Paths.get("bogus"), path)));
+            assertThat(index.getEntry("foo://file.bin"), is(nullValue()));
+        }
     }
 }


### PR DESCRIPTION
- protected against the case when the user removes a file from cache
- flipped the default value of followRedirects
- removed the cached file size limit
- successful responses were being retried

@longtimeago please review