### PR TITLE
Fix proxy support without authentication in wget

### DIFF
--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -580,7 +580,7 @@ public class WGetMojo extends AbstractMojo {
                     ? uri.getScheme()
                     : null,
                 isBlank(serverId)
-                    ? uri.getHost()
+                    ? uri.getScheme() + "://" + uri.getHost()
                     : null)
                 .build();
     }
@@ -630,10 +630,12 @@ public class WGetMojo extends AbstractMojo {
 
         try ( final AuthenticationContext ctx = AuthenticationContext.forProxy(this.session.getRepositorySession(),
                 proxyRepo) ) {
-            fileRequesterBuilder.withProxyUserName(ctx.get(AuthenticationContext.USERNAME));
-            fileRequesterBuilder.withProxyPassword(ctx.get(AuthenticationContext.PASSWORD));
-            fileRequesterBuilder.withNtlmDomain(ctx.get(AuthenticationContext.NTLM_DOMAIN));
-            fileRequesterBuilder.withNtlmHost(ctx.get(AuthenticationContext.NTLM_WORKSTATION));
+            if (ctx != null) {
+                fileRequesterBuilder.withProxyUserName(ctx.get(AuthenticationContext.USERNAME));
+                fileRequesterBuilder.withProxyPassword(ctx.get(AuthenticationContext.PASSWORD));
+                fileRequesterBuilder.withNtlmDomain(ctx.get(AuthenticationContext.NTLM_DOMAIN));
+                fileRequesterBuilder.withNtlmHost(ctx.get(AuthenticationContext.NTLM_WORKSTATION));
+            }
         }
     }
 


### PR DESCRIPTION
Prefixing uri.getHost() with uri.getScheme() + "://" in method createRemoteRepository when instantiating RemoteRepository.Builder so that property "host" will be populated on build.

When "host" is not populated, the correct proxy is not selected for the remote repository. Also modified method addProxy against NPE when ctx is null (no authentication needed)