### PR TITLE
Add support for wget unpackWhenChanged setting

### DIFF
--- a/src/it/GetAndUnpackWhenChanged/invoke.properties
+++ b/src/it/GetAndUnpackWhenChanged/invoke.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean package
+invoker.buildResult = success
+invoker.goals.2 = clean package
+invoker.buildResult.2 = success

--- a/src/it/GetAndUnpackWhenChanged/pom.xml
+++ b/src/it/GetAndUnpackWhenChanged/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- Build description -->
+	<groupId>com.googlecode.maven-download-plugin.it</groupId>
+	<artifactId>testBasic</artifactId>
+	<packaging>pom</packaging>
+    <version>${testing.versionUnderTest}</version>
+	<name>Test</name>
+
+	<!-- Build plugins and extensions -->
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<!-- downloading a locally hosted jar archive, containing a "Hello, world!" text -->
+							<url>@mrm.repository.url@/localhost/hello/1.0/hello-1.0.jar</url>
+							<outputDirectory>${project.basedir}/unpacked</outputDirectory>
+							<unpackWhenChanged>true</unpackWhenChanged>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/it/GetAndUnpackWhenChanged/verify.groovy
+++ b/src/it/GetAndUnpackWhenChanged/verify.groovy
@@ -1,0 +1,5 @@
+def f = new File(basedir, "unpacked/hello.txt")
+assert f.text == "Hello, world!"
+def log = new File(basedir, "build.log")
+assert log.exists() : "$log does not exist"
+assert log.text =~ /Skipping unpacking as the file has not changed/ : "$log does not contain unpack skip message"


### PR DESCRIPTION
Adds support for an `unpackWhenChanged` setting in the WGet goal, which will only unpack a downloaded file when it was not already present in the cache.

This is useful for executions which unpack downloads into non-transient directories (i.e. not `./target`) which only need subsequent unpacking when the source dependency archive changes.