### PR TITLE
rise java build requirement to v11 (due to mockito)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <httpclient.version>4.5.14</httpclient.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <maven.version>3.2.5</maven.version>
     </properties>
 


### PR DESCRIPTION
plugin still works in 1.8 projects