### PR TITLE
Unpack directly from cached files when available

### DIFF
--- a/src/it/GetAndUnpackWhenChanged/pom.xml
+++ b/src/it/GetAndUnpackWhenChanged/pom.xml
@@ -26,6 +26,8 @@
 							<url>@mrm.repository.url@/localhost/hello/1.0/hello-1.0.jar</url>
 							<outputDirectory>${project.basedir}/unpacked</outputDirectory>
 							<unpackWhenChanged>true</unpackWhenChanged>
+							<!-- use a separate cache to ensure hello-1.0.jar isn't already cached on first run-->
+							<cacheDirectory>${project.basedir}/unpackWhenChangedCache</cacheDirectory>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/reuseCacheFromOlderVersion/verify.groovy
+++ b/src/it/reuseCacheFromOlderVersion/verify.groovy
@@ -1,1 +1,1 @@
-assert new File(basedir, "build.log").text.contains('[DEBUG] Got from cache:')
+assert new File(basedir, "build.log").text.contains('[DEBUG] File was cached:')


### PR DESCRIPTION
If downloaded files are archives to be unpacked and files are cached, unpack the cached files directly instead of copying them to the outputFile path first. This saves time and storage and prevents strange behavior with the new unpackWhenChanged option (cached files were being copied to outputFile and then left there since the archives were not unpacked due to unchanged downloads).