### PR TITLE
Force unpack if unpack=true, even when unpackWhenChanged=true

### DIFF
--- a/src/it/GetAndUnpackWhenChanged/invoke.properties
+++ b/src/it/GetAndUnpackWhenChanged/invoke.properties
@@ -2,3 +2,5 @@ invoker.goals = clean package
 invoker.buildResult = success
 invoker.goals.2 = clean package
 invoker.buildResult.2 = success
+invoker.goals.3 = clean package -Ddownload.unpack=true
+invoker.buildResult.3 = success

--- a/src/it/GetAndUnpackWhenChanged/verify.groovy
+++ b/src/it/GetAndUnpackWhenChanged/verify.groovy
@@ -3,3 +3,4 @@ assert f.text == "Hello, world!"
 def log = new File(basedir, "build.log")
 assert log.exists() : "$log does not exist"
 assert log.text =~ /Skipping unpacking as the file has not changed/ : "$log does not contain unpack skip message"
+assert log.text =~ /Unpacking even though unchanged cache file exists/ : "$log does not contain force unpack message"

--- a/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
+++ b/src/main/java/com/googlecode/download/maven/plugin/internal/WGetMojo.java
@@ -540,9 +540,12 @@ public class WGetMojo extends AbstractMojo {
                 cache.get().install(this.uri, outputFile, checksums);
             }
             if (this.unpack || this.unpackWhenChanged) {
-                if (this.unpackWhenChanged && fileWasCached) {
+                if (!this.unpack && this.unpackWhenChanged && fileWasCached) {
                     getLog().info("Skipping unpacking as the file has not changed");
                 } else {
+                    if (this.unpackWhenChanged && fileWasCached) {
+                        getLog().info("Unpacking even though unchanged cache file exists because unpack = true");
+                    }
                     this.unpack(outputFile, cachedFile);
                     this.buildContext.refresh(this.outputDirectory);
                 }


### PR DESCRIPTION
Small change to always unpack an unchanged cached archive if unpack is true, even if unpackWhenChanged is true. This allows users to force unpacking when the archives are cached/unchanged but the unpack target directory doesn't already contain the unpacked data (example Github Actions/CI builds).